### PR TITLE
fix: evict stale PR status cache entries

### DIFF
--- a/src/app/api/pr-status/route.ts
+++ b/src/app/api/pr-status/route.ts
@@ -123,6 +123,9 @@ export async function POST(request: Request) {
     }
 
     const now = Date.now();
+    for (const [key, entry] of cache) {
+      if (now - entry.ts > CACHE_TTL_MS) cache.delete(key);
+    }
     const results: Record<string, PrStatus | null> = {};
 
     const fetches = prUrls.map(async (url, i) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Add `"target": "ES2020"` to tsconfig.json — Next.js recommended default, was missing (TS defaulted to ES3)
- Add cache eviction sweep in PR status API route — expired entries (>30s TTL) were never deleted, causing unbounded memory growth over long Electron sessions

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` — 94 tests pass
- [x] `npm run lint` — clean