### PR TITLE
chore: add .env to gitignore, remove dead tailwind content path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@ next-app-dist/
 tmp/
 .DS_Store
 
+# Environment variables
+.env
+.env*.local
+
 # Claude Code
 .claude/worktrees/

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,6 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],


### PR DESCRIPTION
## Summary
- Add `.env` and `.env*.local` patterns to `.gitignore` to prevent accidental credential commits (Next.js auto-loads `.env.local`)
- Remove dead `./src/pages/**/*` content path from `tailwind.config.ts` (App Router only, no `src/pages/` directory exists)

## Test plan
- Verify `.env` files are ignored by git
- Verify Tailwind CSS still processes all component and app directory files correctly