### PR TITLE
fix: cache getPrUrl to avoid GitHub API rate limit exhaustion

### DIFF
--- a/src/lib/git-info.ts
+++ b/src/lib/git-info.ts
@@ -57,15 +57,28 @@ export async function getGitDiff(cwd: string): Promise<string | null> {
   return diff || null;
 }
 
+// Cache: branch → { url, timestamp }
+const prUrlCache = new Map<string, { url: string | null; ts: number }>();
+const PR_URL_TTL_MS = 60_000;       // 60s for known PR URLs
+const PR_URL_NULL_TTL_MS = 30_000;  // 30s for "no PR" results
+
 export async function getPrUrl(cwd: string, branch: string): Promise<string | null> {
+  const cached = prUrlCache.get(branch);
+  if (cached) {
+    const ttl = cached.url ? PR_URL_TTL_MS : PR_URL_NULL_TTL_MS;
+    if (Date.now() - cached.ts < ttl) return cached.url;
+  }
+
   try {
     const { stdout } = await execFileAsync("gh", ["pr", "view", branch, "--json", "url", "--jq", ".url"], {
       cwd,
       timeout: 5000,
     });
-    const url = stdout.trim();
-    return url || null;
+    const url = stdout.trim() || null;
+    prUrlCache.set(branch, { url, ts: Date.now() });
+    return url;
   } catch {
+    prUrlCache.set(branch, { url: null, ts: Date.now() });
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Cache `getPrUrl()` results per branch with 60s TTL (30s for null/no-PR results)
- Reduces `gh` API calls from ~300/min (10 sessions × 2s poll) to ~10/min
- Prevents GitHub GraphQL rate limit exhaustion (~5,000/hour) during normal use

## Risk areas
- Cache uses branch name as key — if a user creates a PR on a branch that previously had no PR, it will take up to 30s to detect it
- Module-level `Map` cache grows unbounded, but in practice branch count is small

## Test plan
- [x] Run with multiple active sessions, monitor `gh` API calls are not fired every poll
- [x] Create a new PR while app is running — verify it appears within ~30s
- [x] Verify PR URLs still display correctly on session cards

Closes #5