### PR TITLE
fix: suppress empty state flash on startup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -179,19 +179,21 @@ export default function Dashboard() {
         </div>
       )}
 
-      <SessionGrid
-        sessions={sessions}
-        viewMode={viewMode}
-        targetScreen={targetScreen}
-        freshlyChanged={freshlyChanged}
-        selectedIndex={selectedIndex}
-        onSelectIndex={setSelectedIndex}
-        actionFeedback={actionFeedback}
-        prStatuses={prStatuses}
-        onNewSessionInRepo={handleNewInRepo}
-        actedSessions={actedSessions}
-        onApproveReject={handleApproveReject}
-      />
+      {!(isLoading && sessions.length === 0) && (
+        <SessionGrid
+          sessions={sessions}
+          viewMode={viewMode}
+          targetScreen={targetScreen}
+          freshlyChanged={freshlyChanged}
+          selectedIndex={selectedIndex}
+          onSelectIndex={setSelectedIndex}
+          actionFeedback={actionFeedback}
+          prStatuses={prStatuses}
+          onNewSessionInRepo={handleNewInRepo}
+          actedSessions={actedSessions}
+          onApproveReject={handleApproveReject}
+        />
+      )}
 
       {sessions.length > 0 && showKeyboardHints && (
         <KeyboardHints

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -3,7 +3,11 @@ import { usePathname } from "next/navigation";
 import { ClaudeSession } from "@/lib/types";
 import { POLL_INTERVAL_MS } from "@/lib/constants";
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
+const fetcher = (url: string) =>
+  fetch(url).then((r) => {
+    if (!r.ok) throw new Error(`${r.status}`);
+    return r.json();
+  });
 
 export function useSessions() {
   const pathname = usePathname();


### PR DESCRIPTION
## Summary
- Hide `SessionGrid` until first discovery cycle completes, preventing "No sessions detected" from flashing alongside the loading spinner on startup
- Fix SWR fetcher to throw on non-OK responses so API errors are properly surfaced (previously a 500 would silently show "No sessions detected")

## Test plan
- Load the dashboard — should see only the spinner, then sessions appear (no empty state flash)
- Simulate API error (return 500 from `/api/sessions`) — should show error banner