### PR TITLE
fix: evict stale entries from getPrUrl cache

### DIFF
--- a/src/lib/git-info.ts
+++ b/src/lib/git-info.ts
@@ -63,11 +63,14 @@ const PR_URL_TTL_MS = 60_000;       // 60s for known PR URLs
 const PR_URL_NULL_TTL_MS = 30_000;  // 30s for "no PR" results
 
 export async function getPrUrl(cwd: string, branch: string): Promise<string | null> {
-  const cached = prUrlCache.get(branch);
-  if (cached) {
-    const ttl = cached.url ? PR_URL_TTL_MS : PR_URL_NULL_TTL_MS;
-    if (Date.now() - cached.ts < ttl) return cached.url;
+  const now = Date.now();
+  for (const [key, entry] of prUrlCache) {
+    const ttl = entry.url ? PR_URL_TTL_MS : PR_URL_NULL_TTL_MS;
+    if (now - entry.ts >= ttl) prUrlCache.delete(key);
   }
+
+  const cached = prUrlCache.get(branch);
+  if (cached) return cached.url;
 
   try {
     const { stdout } = await execFileAsync("gh", ["pr", "view", branch, "--json", "url", "--jq", ".url"], {


### PR DESCRIPTION
## Summary
- Add eviction sweep at the top of `getPrUrl()` to delete expired cache entries
- Prevents unbounded `Map` growth over long-running sessions
- Same pattern already used in `pr-status/route.ts` cache

## Test plan
- `npm run typecheck` — clean
- `npm run test` — 296 tests pass
- Behavioral: PR URLs still cache correctly (60s for found PRs, 30s for null results), stale entries are cleaned up on next call