### PR TITLE
fix: PID-to-JSONL mapping via hook events

### DIFF
--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -163,8 +163,9 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
 
   // Collect transcript paths claimed by hook events so fallback doesn't reuse them
   const claimedPaths = new Set<string>();
+  const activePids = new Set(pids);
   for (const [pid, hook] of hookStatuses) {
-    if (hook.transcriptPath && pids.includes(pid)) {
+    if (hook.transcriptPath && activePids.has(pid)) {
       claimedPaths.add(hook.transcriptPath);
     }
   }

--- a/src/lib/hooks-installer.ts
+++ b/src/lib/hooks-installer.ts
@@ -40,6 +40,7 @@ fi
 
 TS=$(date +%s)
 
+# $PPID = Claude process that invoked this hook (keys the event file by PID)
 echo "{\\"event\\":\\"$HOOK_EVENT\\",\\"session_id\\":\\"$SESSION_ID\\",\\"cwd\\":\\"$CWD\\",\\"transcript_path\\":\\"$TRANSCRIPT\\",\\"ts\\":$TS}" > "$EVENTS_DIR/$PPID.json"
 `;
 

--- a/src/lib/hooks-reader.ts
+++ b/src/lib/hooks-reader.ts
@@ -43,7 +43,7 @@ export async function readAllHookStatuses(): Promise<Map<number, HookStatus>> {
 
   await Promise.all(
     entries
-      .filter((e) => e.endsWith(".json") || e.endsWith(".jsonl"))
+      .filter((e) => e.endsWith(".json"))
       .map(async (filename) => {
         const filePath = join(EVENTS_DIR, filename);
 
@@ -66,17 +66,11 @@ export async function readAllHookStatuses(): Promise<Map<number, HookStatus>> {
         }
         if (!content) return;
 
-        // For old .jsonl files (multi-line), take the last line
-        const line = content.includes("\n")
-          ? content.split("\n").filter((l) => l.trim()).pop() ?? ""
-          : content;
-
         try {
-          const data = JSON.parse(line) as {
+          const data = JSON.parse(content) as {
             event?: string;
             session_id?: string;
             cwd?: string;
-            pid?: number;
             transcript_path?: string;
             ts?: number;
           };
@@ -86,18 +80,14 @@ export async function readAllHookStatuses(): Promise<Map<number, HookStatus>> {
           const status = classifyStatusFromHook(data.event);
           if (!status) return;
 
-          // PID from filename (.json) or from payload (.jsonl legacy)
-          const pid = filename.endsWith(".json")
-            ? parseInt(filename.replace(/\.json$/, ""), 10)
-            : data.pid;
-
-          if (pid == null || isNaN(pid)) return;
+          const pid = parseInt(filename.replace(/\.json$/, ""), 10);
+          if (isNaN(pid)) return;
 
           result.set(pid, {
             status,
             event: data.event,
             ts: data.ts ?? 0,
-            cwd: data.cwd ?? null,
+            cwd: data.cwd || null,
             sessionId: data.session_id || null,
             transcriptPath: data.transcript_path || null,
           });


### PR DESCRIPTION
## Summary

Fixes #10 — when multiple Claude PIDs share the same working directory, `findLatestJsonl()` returned the same JSONL for all of them, showing the wrong conversation.

Fixes #8 — when a session uses `EnterWorktree`, the CWD changes but the real JSONL stays in the original project directory. Hook events carry `transcript_path` directly, bypassing the CWD→projectDir→findLatestJsonl chain entirely.

**Root cause:** Hook event files were keyed by session ID (`<session-id>.jsonl`), so multiple files could reference the same PID. After `/clear`, `SessionEnd` and `SessionStart` fired in the same second (`date +%s`), causing a timestamp tie with non-deterministic resolution — the UI would flash between old and new conversations.

**Fix:** Key event files by PID (`<pid>.json`) instead of session ID. Each Claude process overwrites its own file on every hook event, providing a direct PID→transcript_path mapping with zero ambiguity.

### Changes

- **`hooks-installer.ts`** — Hook script writes to `$PPID.json` (PID-keyed, overwrite) instead of `$SESSION_ID.jsonl` (session-keyed, append). Extracts `transcript_path` from hook stdin.
- **`hooks-reader.ts`** — Returns `Map<number, HookStatus>` keyed by PID. Simplified from `readLastLine` seek logic to plain `readFile` (single-line files). `HookStatus` now carries `sessionId` and `transcriptPath`.
- **`discovery.ts`** — Direct PID→hook lookup replaces the old scan-all-events-and-resolve approach. `claimedPaths` set prevents mtime-based fallback from reusing hook-claimed transcript paths.

### How it handles each scenario

| Scenario | Resolution |
|----------|-----------|
| Single PID, hooks active | Hook provides direct PID→JSONL |
| Multiple PIDs same project | Each PID has its own `<pid>.json` → distinct transcripts |
| `/clear` | `SessionEnd` then `SessionStart` overwrite the same file — last write wins |
| `--continue` / resume | New PID writes `<new-pid>.json` with continued session's transcript |
| Worktree mid-session | Hook carries real `transcript_path` regardless of CWD change |
| No hooks yet (fresh install) | Falls back to `findLatestJsonl` (mtime-based, same as before) |
| One PID has hooks, one doesn't | Hook-claimed path excluded from fallback via `claimedPaths` |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 296 tests pass
- [x] Manual: run 2 Claude sessions in the same project, verify each card shows correct conversation
- [x] Manual: `/clear` in one session, verify card updates to new (empty) conversation
- [ ] Manual: `EnterWorktree` mid-session, verify card still shows full conversation
- [ ] Manual: verify sessions without hook events fall back to mtime-based discovery