### PR TITLE
feat: orphaned session detection, tmux reattach, and README terminal updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When you're running several Claude Code instances across different repos and wor
 - **Desktop notifications** — Native macOS notifications when sessions finish working or need attention (configurable)
 - **Notification sounds** — Subtle two-tone chime on status transitions (configurable)
 - **Quick actions** — One-click buttons to focus the terminal tab, open your editor, git GUI, Finder, or PR link for any session
-- **Multiple terminal support** — Full tab-level control for iTerm2, Terminal.app, and kitty; basic support for Ghostty, WezTerm, Warp, and Alacritty (see [Terminal support](#terminal-support))
+- **Multiple terminal support** — Full tab-level control for iTerm2, Terminal.app, kitty, and WezTerm; basic support for Ghostty, Warp, and Alacritty (see [Terminal support](#terminal-support))
 - **tmux integration** — Run sessions inside tmux with per-project session grouping or manual session selection; approve/reject without terminal focus via `send-keys`
 - **Configurable tools** — Choose your preferred terminal, code editor (VS Code, Cursor, Zed, etc.), git GUI (Fork, Sublime Merge, etc.), and browser (Chrome, Arc, Safari, etc.)
 - **New session creation** — Create new Claude Code sessions with git worktree support, repo browsing, and custom initial prompts
@@ -148,7 +148,8 @@ These terminals support tab-level focus, text input, and keystroke sending — c
 |---|---|---|
 | [**Terminal.app**](https://support.apple.com/guide/terminal/) | AppleScript (TTY matching) | Matches tabs by TTY, uses System Events for keystrokes. Works out of the box. |
 | [**iTerm2**](https://iterm2.com/) | AppleScript (TTY matching) | Iterates windows/tabs/sessions, matches by TTY path. Native `write text` for keystrokes. Works out of the box. |
-| [**kitty**](https://sw.kovidgoyal.net/kitty/) | Remote control (Unix socket) | Uses `kitten @` IPC to resolve window by PID, then focus by window ID. Requires configuration (see below). |
+| [**kitty**](https://sw.kovidgoyal.net/kitty/) | Remote control (Unix socket) | Uses `kitten @` IPC to resolve window by PID, then focus by window ID. Supports tmux-in-kitty matching. Requires configuration (see below). |
+| [**WezTerm**](https://wezfurlong.org/wezterm/) | CLI (`wezterm cli`) | Uses `wezterm cli` to list panes, focus by pane ID, and send text directly. Works out of the box. |
 
 #### kitty configuration
 
@@ -179,7 +180,6 @@ These terminals are detected and can be activated, but focus goes to the app —
 | Terminal | Notes |
 |---|---|
 | [**Ghostty**](https://ghostty.org/) | Has AppleScript support since v1.3 but lacks PID/TTY properties for tab matching ([#10756](https://github.com/ghostty-org/ghostty/issues/10756)). Full support expected when 1.4 ships. |
-| [**WezTerm**](https://wezfurlong.org/wezterm/) | No tab-level IPC available. |
 | [**Warp**](https://www.warp.dev/) | No tab-level IPC available. |
 | [**Alacritty**](https://alacritty.org/) | No tabs by design — use tmux for multi-session workflows. |
 

--- a/src/app/api/actions/open/route.ts
+++ b/src/app/api/actions/open/route.ts
@@ -1,15 +1,15 @@
-import { NextResponse } from "next/server";
-import { execFile, exec } from "child_process";
-import { promisify } from "util";
+import { exec, execFile } from "child_process";
 import { stat } from "fs/promises";
-import { loadConfig, EDITOR_OPTIONS, GIT_GUI_OPTIONS, BROWSER_OPTIONS } from "@/lib/config";
+import { NextResponse } from "next/server";
+import { promisify } from "util";
+import { BROWSER_OPTIONS, EDITOR_OPTIONS, GIT_GUI_OPTIONS, loadConfig } from "@/lib/config";
 import {
   buildProcessTree,
   detectAllTmuxPanes,
   detectTerminal,
   focusSession,
-  sendText,
   sendKeystroke,
+  sendText,
 } from "@/lib/terminal";
 
 const execFileAsync = promisify(execFile);

--- a/src/app/api/pr-status/route.ts
+++ b/src/app/api/pr-status/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
 import { execFile } from "child_process";
+import { NextResponse } from "next/server";
 import { promisify } from "util";
-import { PrStatus, PrChecks } from "@/lib/types";
+import { PrChecks, PrStatus } from "@/lib/types";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/app/api/repos/route.ts
+++ b/src/app/api/repos/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
-import { readdir, stat } from "fs/promises";
-import { join } from "path";
-import { homedir } from "os";
 import { execFile } from "child_process";
+import { readdir, stat } from "fs/promises";
+import { NextResponse } from "next/server";
+import { homedir } from "os";
+import { join } from "path";
 import { promisify } from "util";
 import { loadConfig, saveConfig } from "@/lib/config";
 

--- a/src/app/api/screens/route.ts
+++ b/src/app/api/screens/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { exec } from "child_process";
+import { NextResponse } from "next/server";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);

--- a/src/app/api/sessions/cleanup/route.ts
+++ b/src/app/api/sessions/cleanup/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { execFile } from "child_process";
+import { NextResponse } from "next/server";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);

--- a/src/app/api/sessions/create/route.ts
+++ b/src/app/api/sessions/create/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
 import { execFile } from "child_process";
-import { promisify } from "util";
 import { stat } from "fs/promises";
+import { NextResponse } from "next/server";
+import { promisify } from "util";
 import { loadConfig } from "@/lib/config";
 import { createSession } from "@/lib/terminal";
 

--- a/src/app/api/sessions/kill/route.ts
+++ b/src/app/api/sessions/kill/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const { pid } = (await request.json()) as { pid: number };
+
+    if (!pid || typeof pid !== "number") {
+      return NextResponse.json({ error: "Missing or invalid pid" }, { status: 400 });
+    }
+
+    try {
+      process.kill(pid, "SIGTERM");
+      await new Promise((r) => setTimeout(r, 1000));
+      try {
+        process.kill(pid, 0);
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already dead
+      }
+    } catch {
+      // Process doesn't exist or already dead — that's fine
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/reattach/route.ts
+++ b/src/app/api/sessions/reattach/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { loadConfig } from "@/lib/config";
+import { getAdapter } from "@/lib/terminal/adapters/registry";
+import type { TerminalApp } from "@/lib/terminal/types";
+
+export async function POST(request: Request) {
+  try {
+    const { tmuxSession, cwd } = (await request.json()) as { tmuxSession: string; cwd: string };
+
+    if (!tmuxSession || typeof tmuxSession !== "string") {
+      return NextResponse.json({ error: "Missing or invalid tmuxSession" }, { status: 400 });
+    }
+
+    const config = await loadConfig();
+    const terminalApp = config.terminalApp as TerminalApp;
+
+    const adapter = getAdapter(terminalApp);
+    if (!adapter) {
+      return NextResponse.json({ error: `No adapter for terminal: ${terminalApp}` }, { status: 400 });
+    }
+
+    // Open a new terminal tab that attaches to the detached tmux session
+    await adapter.createSession(`tmux attach -t '${tmuxSession}'`, {
+      openIn: config.terminalOpenIn ?? "tab",
+      useTmux: false,
+      cwd: cwd || "/tmp",
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { discoverSessions } from "@/lib/discovery";
-import { ensureHooksInstalled, areHooksInstalled } from "@/lib/hooks-installer";
+import { areHooksInstalled, ensureHooksInstalled } from "@/lib/hooks-installer";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from "next/server";
 import { execFile } from "child_process";
+import { NextResponse } from "next/server";
 import { promisify } from "util";
 import {
-  loadConfig,
-  saveConfig,
   AppConfig,
+  BROWSER_OPTIONS,
   EDITOR_OPTIONS,
   GIT_GUI_OPTIONS,
-  BROWSER_OPTIONS,
+  loadConfig,
+  saveConfig,
   TERMINAL_APP_OPTIONS,
   TERMINAL_OPEN_IN_OPTIONS,
   TERMINAL_TMUX_MODE_OPTIONS,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,19 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { useSessions } from "@/hooks/useSessions";
-import { useNotificationSound } from "@/hooks/useNotificationSound";
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { DashboardHeader } from "@/components/DashboardHeader";
+import { KeyboardHints } from "@/components/KeyboardHints";
+import { NewSessionModal } from "@/components/NewSessionModal";
+import { SessionGrid } from "@/components/SessionGrid";
 import { useDesktopNotification } from "@/hooks/useDesktopNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useNotificationSound } from "@/hooks/useNotificationSound";
 import { usePrStatus } from "@/hooks/usePrStatus";
+import { useSessions } from "@/hooks/useSessions";
 import { useSettings } from "@/hooks/useSettings";
-import { DashboardHeader } from "@/components/DashboardHeader";
-import { ViewMode } from "@/lib/types";
-import { SessionGrid } from "@/components/SessionGrid";
-import { NewSessionModal } from "@/components/NewSessionModal";
-import { KeyboardHints } from "@/components/KeyboardHints";
-import { SessionStatus } from "@/lib/types";
 import { flattenGroupedSessions } from "@/lib/group-sessions";
-import Link from "next/link";
+import { SessionStatus, ViewMode } from "@/lib/types";
 
 export default function Dashboard() {
   const { sessions, isLoading, error, hooksActive, refresh } = useSessions();

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState } from "react";
-import { useParams } from "next/navigation";
 import Link from "next/link";
-import { useSession } from "@/hooks/useSession";
-import { StatusBadge } from "@/components/StatusBadge";
-import { GitSummary } from "@/components/GitSummary";
+import { useParams } from "next/navigation";
+import { useState } from "react";
 import { ConversationView } from "@/components/ConversationView";
+import { GitSummary } from "@/components/GitSummary";
 import { QuickActions } from "@/components/QuickActions";
+import { StatusBadge } from "@/components/StatusBadge";
+import { useSession } from "@/hooks/useSession";
 
 export default function SessionDetailPage() {
   const params = useParams();

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ScreenPicker } from "@/components/ScreenPicker";
 
 interface OptionDef {

--- a/src/components/KeyboardHints.tsx
+++ b/src/components/KeyboardHints.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { ClaudeSession } from "@/lib/types";
 import { useSettings } from "@/hooks/useSettings";
+import { ClaudeSession } from "@/lib/types";
 
 function Kbd({ children }: { children: React.ReactNode }) {
   return (

--- a/src/components/NewSessionModal.tsx
+++ b/src/components/NewSessionModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface RepoInfo {
   name: string;

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -40,6 +40,7 @@ export function QuickActions({
   targetScreen,
   status,
   prUrl,
+  orphaned,
   onCleanup,
 }: {
   path: string;
@@ -47,9 +48,29 @@ export function QuickActions({
   targetScreen?: number | null;
   status?: string;
   prUrl?: string | null;
+  orphaned?: boolean;
   onCleanup?: (e: React.MouseEvent) => void;
 }) {
   const [prSending, setPrSending] = useState(false);
+  const [killing, setKilling] = useState(false);
+
+  const killSession = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!pid) return;
+    setKilling(true);
+    try {
+      await fetch("/api/sessions/kill", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pid }),
+      });
+    } catch (err) {
+      console.error("Kill failed:", err);
+    }
+    // Reset after 3s in case session doesn't disappear immediately
+    setTimeout(() => setKilling(false), 3000);
+  };
   const { editorAvailable, gitGuiAvailable } = useSettings();
 
   const openAction = async (e: React.MouseEvent, action: string) => {
@@ -141,7 +162,21 @@ export function QuickActions({
         </IconButton>
       ) : null}
 
-      {pid && (
+      {pid && orphaned ? (
+        <IconButton
+          onClick={killSession}
+          tip={killing ? "Killing..." : "Kill orphaned session"}
+          className={`flex-1 flex items-center justify-center h-8 rounded-lg ${
+            killing
+              ? "bg-orange-500/10 border-orange-500/20 text-orange-400"
+              : "bg-white/4 hover:bg-orange-500/12 border border-white/7 hover:border-orange-500/25 text-zinc-500 hover:text-orange-400"
+          } transition-all duration-150`}
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </IconButton>
+      ) : pid ? (
         <IconButton onClick={(e) => openAction(e, "focus")} tip="Terminal" className={`flex-1 ${iconBtnClass}`}>
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path
@@ -151,7 +186,7 @@ export function QuickActions({
             />
           </svg>
         </IconButton>
-      )}
+      ) : null}
       {editorAvailable && (
         <IconButton onClick={(e) => openAction(e, "editor")} tip="Editor" className={`flex-1 ${iconBtnClass}`}>
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -41,6 +41,7 @@ export function QuickActions({
   status,
   prUrl,
   orphaned,
+  tmuxSession,
   onCleanup,
 }: {
   path: string;
@@ -49,6 +50,7 @@ export function QuickActions({
   status?: string;
   prUrl?: string | null;
   orphaned?: boolean;
+  tmuxSession?: string | null;
   onCleanup?: (e: React.MouseEvent) => void;
 }) {
   const [prSending, setPrSending] = useState(false);
@@ -71,6 +73,26 @@ export function QuickActions({
     // Reset after 3s in case session doesn't disappear immediately
     setTimeout(() => setKilling(false), 3000);
   };
+
+  const [reattaching, setReattaching] = useState(false);
+
+  const reattachSession = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!tmuxSession) return;
+    setReattaching(true);
+    try {
+      await fetch("/api/sessions/reattach", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tmuxSession, cwd: path }),
+      });
+    } catch (err) {
+      console.error("Reattach failed:", err);
+    }
+    setTimeout(() => setReattaching(false), 3000);
+  };
+
   const { editorAvailable, gitGuiAvailable } = useSettings();
 
   const openAction = async (e: React.MouseEvent, action: string) => {
@@ -163,19 +185,36 @@ export function QuickActions({
       ) : null}
 
       {pid && orphaned ? (
-        <IconButton
-          onClick={killSession}
-          tip={killing ? "Killing..." : "Kill orphaned session"}
-          className={`flex-1 flex items-center justify-center h-8 rounded-lg ${
-            killing
-              ? "bg-orange-500/10 border-orange-500/20 text-orange-400"
-              : "bg-white/4 hover:bg-orange-500/12 border border-white/7 hover:border-orange-500/25 text-zinc-500 hover:text-orange-400"
-          } transition-all duration-150`}
-        >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </IconButton>
+        <>
+          {tmuxSession && (
+            <IconButton
+              onClick={reattachSession}
+              tip={reattaching ? "Reattaching..." : "Reattach tmux session"}
+              className={`flex-1 flex items-center justify-center h-8 rounded-lg ${
+                reattaching
+                  ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-400"
+                  : "bg-white/4 hover:bg-emerald-500/12 border border-white/7 hover:border-emerald-500/25 text-zinc-500 hover:text-emerald-400"
+              } transition-all duration-150`}
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 15l6-6m-5.5.5h.01m4.99 5h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </IconButton>
+          )}
+          <IconButton
+            onClick={killSession}
+            tip={killing ? "Killing..." : "Kill orphaned session"}
+            className={`flex-1 flex items-center justify-center h-8 rounded-lg ${
+              killing
+                ? "bg-orange-500/10 border-orange-500/20 text-orange-400"
+                : "bg-white/4 hover:bg-orange-500/12 border border-white/7 hover:border-orange-500/25 text-zinc-500 hover:text-orange-400"
+            } transition-all duration-150`}
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </IconButton>
+        </>
       ) : pid ? (
         <IconButton onClick={(e) => openAction(e, "focus")} tip="Terminal" className={`flex-1 ${iconBtnClass}`}>
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -197,7 +197,11 @@ export function QuickActions({
               } transition-all duration-150`}
             >
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 15l6-6m-5.5.5h.01m4.99 5h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 15l6-6m-5.5.5h.01m4.99 5h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
               </svg>
             </IconButton>
           )}

--- a/src/components/QuickReply.tsx
+++ b/src/components/QuickReply.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useRef, useState } from "react";
 import { refreshAfterAction, sendKeystrokeAction } from "@/lib/actions";
 import type { ToolInfo } from "@/lib/types";
 

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -296,6 +296,7 @@ export function SessionCard({
               status={displayStatus}
               prUrl={session.prUrl}
               orphaned={session.orphaned}
+              tmuxSession={session.tmuxSession}
               onCleanup={canCleanup ? handleCleanup : undefined}
             />
           )}

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -206,7 +206,7 @@ export function SessionCard({
                 {session.workingDirectory.replace(/.*\/([^/]+\/[^/]+)$/, "$1")}
               </p>
             </div>
-            <StatusBadge status={displayStatus} />
+            <StatusBadge status={displayStatus} orphaned={session.orphaned} />
           </div>
 
           {/* Git info + PR status */}
@@ -295,6 +295,7 @@ export function SessionCard({
               targetScreen={targetScreen}
               status={displayStatus}
               prUrl={session.prUrl}
+              orphaned={session.orphaned}
               onCleanup={canCleanup ? handleCleanup : undefined}
             />
           )}

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { ClaudeSession, SessionStatus, PrStatus } from "@/lib/types";
-import { StatusBadge } from "./StatusBadge";
+import { ClaudeSession, PrStatus, SessionStatus } from "@/lib/types";
 import { GitSummary } from "./GitSummary";
 import { OutputPreview } from "./OutputPreview";
-import { TaskSummaryView } from "./TaskSummaryView";
 import { PrStatusBadge } from "./PrStatusBadge";
 import { QuickActions } from "./QuickActions";
 import { QuickReply } from "./QuickReply";
+import { StatusBadge } from "./StatusBadge";
+import { TaskSummaryView } from "./TaskSummaryView";
 
 function timeAgo(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime();

--- a/src/components/SessionGrid.tsx
+++ b/src/components/SessionGrid.tsx
@@ -1,11 +1,10 @@
 "use client";
 
+import { sendKeystrokeAction } from "@/lib/actions";
+import { groupSessions } from "@/lib/group-sessions";
 import { ClaudeSession, PrStatus, ViewMode } from "@/lib/types";
 import { SessionCard } from "./SessionCard";
 import { SessionRow } from "./SessionRow";
-import { sendKeystrokeAction } from "@/lib/actions";
-
-import { groupSessions } from "@/lib/group-sessions";
 
 function prettifyName(name: string): string {
   return name.replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());

--- a/src/components/SessionRow.tsx
+++ b/src/components/SessionRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ClaudeSession, SessionStatus, PrStatus, statusLabels } from "@/lib/types";
+import { ClaudeSession, PrStatus, SessionStatus, statusLabels } from "@/lib/types";
 import { PrStatusBadge } from "./PrStatusBadge";
 
 const statusColors: Record<SessionStatus, { dot: string; text: string }> = {
@@ -68,9 +68,7 @@ export function SessionRow({
         </span>
         <span className={`text-xs font-medium ${colors.text}`}>{statusLabels[displayStatus]}</span>
         {session.orphaned && (
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-orange-400">
-            Orphaned
-          </span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-orange-400">Orphaned</span>
         )}
       </div>
 

--- a/src/components/SessionRow.tsx
+++ b/src/components/SessionRow.tsx
@@ -59,7 +59,7 @@ export function SessionRow({
       )}
 
       {/* Status dot + label */}
-      <div className="shrink-0 flex items-center gap-2 w-[80px]">
+      <div className="shrink-0 flex items-center gap-2 w-[140px]">
         <span className="relative flex h-2 w-2 shrink-0">
           {displayStatus === "working" && (
             <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-50" />
@@ -67,6 +67,11 @@ export function SessionRow({
           <span className={`relative inline-flex h-2 w-2 rounded-full ${colors.dot}`} />
         </span>
         <span className={`text-xs font-medium ${colors.text}`}>{statusLabels[displayStatus]}</span>
+        {session.orphaned && (
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-orange-400">
+            Orphaned
+          </span>
+        )}
       </div>
 
       {/* Repo / branch name */}

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -8,14 +8,22 @@ const statusConfig: Record<SessionStatus, { dotColor: string; textColor: string;
   finished: { dotColor: "bg-zinc-500", textColor: "text-zinc-400", bgColor: "bg-zinc-500/10", pulse: false },
 };
 
-export function StatusBadge({ status }: { status: SessionStatus }) {
+export function StatusBadge({ status, orphaned }: { status: SessionStatus; orphaned?: boolean }) {
   const config = statusConfig[status];
   return (
-    <span
-      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider ${config.textColor} ${config.bgColor}`}
-    >
-      <span className={`h-1.5 w-1.5 rounded-full ${config.dotColor} ${config.pulse ? "animate-soft-pulse" : ""}`} />
-      {statusLabels[status]}
-    </span>
+    <div className="flex items-center gap-1.5">
+      {orphaned && (
+        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider text-orange-300 bg-orange-500/10">
+          <span className="h-1.5 w-1.5 rounded-full bg-orange-400" />
+          Orphaned
+        </span>
+      )}
+      <span
+        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider ${config.textColor} ${config.bgColor}`}
+      >
+        <span className={`h-1.5 w-1.5 rounded-full ${config.dotColor} ${config.pulse ? "animate-soft-pulse" : ""}`} />
+        {statusLabels[status]}
+      </span>
+    </div>
   );
 }

--- a/src/components/TaskSummaryView.tsx
+++ b/src/components/TaskSummaryView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { TaskSummary } from "@/lib/types";
 
 interface TaskSummaryViewProps {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useCallback, useState, useMemo } from "react";
-import { ClaudeSession, ViewMode } from "@/lib/types";
-import { flattenGroupedSessions } from "@/lib/group-sessions";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { sendKeystrokeAction } from "@/lib/actions";
+import { flattenGroupedSessions } from "@/lib/group-sessions";
+import { ClaudeSession, ViewMode } from "@/lib/types";
 import { useSettings } from "./useSettings";
 
 interface UseKeyboardShortcutsOptions {

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,6 +1,6 @@
 import useSWR from "swr";
-import { SessionDetail } from "@/lib/types";
 import { POLL_INTERVAL_MS } from "@/lib/constants";
+import { SessionDetail } from "@/lib/types";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -1,7 +1,7 @@
-import useSWR from "swr";
 import { usePathname } from "next/navigation";
-import { ClaudeSession } from "@/lib/types";
+import useSWR from "swr";
 import { POLL_INTERVAL_MS } from "@/lib/constants";
+import { ClaudeSession } from "@/lib/types";
 
 const fetcher = (url: string) =>
   fetch(url).then((r) => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,6 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
+import { join } from "path";
 import type { TerminalApp, TerminalOpenIn } from "./terminal/types";
 
 const CONFIG_DIR = join(homedir(), ".claude-control");

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,3 +18,4 @@ export const WORKING_THRESHOLD_MS = 10 * 1000;
 export const PROCESS_TIMEOUT_MS = 5000;
 export const APPLESCRIPT_FOCUS_DELAY_S = 0.2;
 export const APPROVAL_SETTLE_MS = 3000;
+export const ORPHAN_CHECK_INTERVAL_MS = 30_000;

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -2,7 +2,8 @@ import { readdir, stat } from "fs/promises";
 import { join } from "path";
 import { ClaudeSession, ConversationPreview } from "./types";
 import { ProcessInfo, getAllProcessInfos } from "./process-utils";
-import { buildProcessTree, findClaudePidsFromTree, evictStaleTerminalCache } from "./terminal/detect";
+import { buildProcessTree, findClaudePidsFromTree, evictStaleTerminalCache, detectAllTmuxPanes, getTtysForPids, isOrphaned } from "./terminal/detect";
+import { ORPHAN_CHECK_INTERVAL_MS } from "./constants";
 import { workingDirToProjectDir, repoNameFromPath } from "./paths";
 import {
   readJsonlTail,
@@ -50,10 +51,15 @@ async function findLatestJsonl(projectDir: string, excludePaths?: Set<string>): 
   }
 }
 
+// Orphan check runs on a slower cadence than the main poll
+let lastOrphanCheck = 0;
+let orphanedPids = new Set<number>();
+
 async function buildSession(
   info: ProcessInfo,
   hookStatus: HookStatus | undefined,
   claimedPaths: Set<string>,
+  orphaned: boolean,
 ): Promise<ClaudeSession | null> {
   if (!info.workingDirectory) return null;
 
@@ -140,6 +146,7 @@ async function buildSession(
     taskSummary,
     jsonlPath,
     prUrl,
+    orphaned,
   };
 }
 
@@ -158,6 +165,22 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
   const activePids = new Set(pids);
   evictStaleTerminalCache(activePids);
 
+  // Orphan check on slower interval — batched to minimize subprocess calls
+  const now = Date.now();
+  if (now - lastOrphanCheck >= ORPHAN_CHECK_INTERVAL_MS) {
+    lastOrphanCheck = now;
+    const [ttyMap, tmuxPanes] = await Promise.all([getTtysForPids(pids), detectAllTmuxPanes()]);
+    const newOrphaned = new Set<number>();
+    for (const pid of pids) {
+      const tty = ttyMap.get(pid);
+      const paneInTmux = tty ? tmuxPanes.has(tty) : false;
+      if (isOrphaned(pid, processTree, paneInTmux)) {
+        newOrphaned.add(pid);
+      }
+    }
+    orphanedPids = newOrphaned;
+  }
+
   // Collect transcript paths claimed by hook events so fallback doesn't reuse them
   const claimedPaths = new Set<string>();
   for (const [pid, hook] of hookStatuses) {
@@ -169,7 +192,7 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
   const results = await Promise.all(
     processInfos
       .filter((info) => info.workingDirectory !== null)
-      .map((info) => buildSession(info, hookStatuses.get(info.pid), claimedPaths)),
+      .map((info) => buildSession(info, hookStatuses.get(info.pid), claimedPaths, orphanedPids.has(info.pid))),
   );
 
   const sessions = results.filter((s): s is ClaudeSession => s !== null);

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -54,12 +54,14 @@ async function findLatestJsonl(projectDir: string, excludePaths?: Set<string>): 
 // Orphan check runs on a slower cadence than the main poll
 let lastOrphanCheck = 0;
 let orphanedPids = new Set<number>();
+let pidTmuxSession = new Map<number, string>();
 
 async function buildSession(
   info: ProcessInfo,
   hookStatus: HookStatus | undefined,
   claimedPaths: Set<string>,
   orphaned: boolean,
+  tmuxSession: string | null,
 ): Promise<ClaudeSession | null> {
   if (!info.workingDirectory) return null;
 
@@ -147,6 +149,7 @@ async function buildSession(
     jsonlPath,
     prUrl,
     orphaned,
+    tmuxSession,
   };
 }
 
@@ -173,6 +176,7 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
     // Build set of tmux session names that have at least one attached client
     const attachedTmuxSessions = new Set(tmuxClients.map((c) => c.sessionName));
     const newOrphaned = new Set<number>();
+    const newPidTmuxSession = new Map<number, string>();
     for (const pid of pids) {
       const tty = ttyMap.get(pid);
       const paneInfo = tty ? tmuxPanes.get(tty) : undefined;
@@ -181,8 +185,12 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
       if (isOrphaned(pid, processTree, inTmux, tmuxSessionHasClient)) {
         newOrphaned.add(pid);
       }
+      if (paneInfo) {
+        newPidTmuxSession.set(pid, paneInfo.sessionName);
+      }
     }
     orphanedPids = newOrphaned;
+    pidTmuxSession = newPidTmuxSession;
   }
 
   // Collect transcript paths claimed by hook events so fallback doesn't reuse them
@@ -196,7 +204,7 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
   const results = await Promise.all(
     processInfos
       .filter((info) => info.workingDirectory !== null)
-      .map((info) => buildSession(info, hookStatuses.get(info.pid), claimedPaths, orphanedPids.has(info.pid))),
+      .map((info) => buildSession(info, hookStatuses.get(info.pid), claimedPaths, orphanedPids.has(info.pid), pidTmuxSession.get(info.pid) ?? null)),
   );
 
   const sessions = results.filter((s): s is ClaudeSession => s !== null);

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -2,7 +2,7 @@ import { readdir, stat } from "fs/promises";
 import { join } from "path";
 import { ClaudeSession, ConversationPreview } from "./types";
 import { ProcessInfo, getAllProcessInfos } from "./process-utils";
-import { buildProcessTree, findClaudePidsFromTree, evictStaleTerminalCache, detectAllTmuxPanes, getTtysForPids, isOrphaned } from "./terminal/detect";
+import { buildProcessTree, findClaudePidsFromTree, evictStaleTerminalCache, detectAllTmuxPanes, detectTmuxClients, getTtysForPids, isOrphaned } from "./terminal/detect";
 import { ORPHAN_CHECK_INTERVAL_MS } from "./constants";
 import { workingDirToProjectDir, repoNameFromPath } from "./paths";
 import {
@@ -169,12 +169,16 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
   const now = Date.now();
   if (now - lastOrphanCheck >= ORPHAN_CHECK_INTERVAL_MS) {
     lastOrphanCheck = now;
-    const [ttyMap, tmuxPanes] = await Promise.all([getTtysForPids(pids), detectAllTmuxPanes()]);
+    const [ttyMap, tmuxPanes, tmuxClients] = await Promise.all([getTtysForPids(pids), detectAllTmuxPanes(), detectTmuxClients()]);
+    // Build set of tmux session names that have at least one attached client
+    const attachedTmuxSessions = new Set(tmuxClients.map((c) => c.sessionName));
     const newOrphaned = new Set<number>();
     for (const pid of pids) {
       const tty = ttyMap.get(pid);
-      const paneInTmux = tty ? tmuxPanes.has(tty) : false;
-      if (isOrphaned(pid, processTree, paneInTmux)) {
+      const paneInfo = tty ? tmuxPanes.get(tty) : undefined;
+      const inTmux = paneInfo !== undefined;
+      const tmuxSessionHasClient = paneInfo ? attachedTmuxSessions.has(paneInfo.sessionName) : false;
+      if (isOrphaned(pid, processTree, inTmux, tmuxSessionHasClient)) {
         newOrphaned.add(pid);
       }
     }

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -1,30 +1,37 @@
 import { readdir, stat } from "fs/promises";
 import { join } from "path";
-import { ClaudeSession, ConversationPreview } from "./types";
-import { ProcessInfo, getAllProcessInfos } from "./process-utils";
-import { buildProcessTree, findClaudePidsFromTree, evictStaleTerminalCache, detectAllTmuxPanes, detectTmuxClients, getTtysForPids, isOrphaned } from "./terminal/detect";
 import { ORPHAN_CHECK_INTERVAL_MS } from "./constants";
-import { workingDirToProjectDir, repoNameFromPath } from "./paths";
+import { getGitDiff, getGitSummary, getMainWorktreePath, getPrUrl } from "./git-info";
+import { type HookStatus, readAllHookStatuses } from "./hooks-reader";
+import { repoNameFromPath, workingDirToProjectDir } from "./paths";
+import { getAllProcessInfos, ProcessInfo } from "./process-utils";
+import { loadSessionMeta } from "./session-meta";
 import {
-  readJsonlTail,
-  readJsonlHead,
-  readFullConversation,
-  extractSessionId,
-  extractStartedAt,
   extractBranch,
   extractPreview,
+  extractSessionId,
+  extractStartedAt,
   extractTaskSummary,
-  lastMessageHasError,
-  isAskingForInput,
-  hasPendingToolUse,
   getJsonlMtime,
+  hasPendingToolUse,
+  isAskingForInput,
+  lastMessageHasError,
   linesToConversation,
+  readFullConversation,
+  readJsonlHead,
+  readJsonlTail,
 } from "./session-reader";
-import { getGitSummary, getGitDiff, getMainWorktreePath, getPrUrl } from "./git-info";
 import { classifyStatus } from "./status-classifier";
-import { readAllHookStatuses, type HookStatus } from "./hooks-reader";
-import { loadSessionMeta } from "./session-meta";
-import { SessionDetail } from "./types";
+import {
+  buildProcessTree,
+  detectAllTmuxPanes,
+  detectTmuxClients,
+  evictStaleTerminalCache,
+  findClaudePidsFromTree,
+  getTtysForPids,
+  isOrphaned,
+} from "./terminal/detect";
+import { ClaudeSession, ConversationPreview, SessionDetail } from "./types";
 
 async function findLatestJsonl(projectDir: string, excludePaths?: Set<string>): Promise<string | null> {
   try {
@@ -172,7 +179,11 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
   const now = Date.now();
   if (now - lastOrphanCheck >= ORPHAN_CHECK_INTERVAL_MS) {
     lastOrphanCheck = now;
-    const [ttyMap, tmuxPanes, tmuxClients] = await Promise.all([getTtysForPids(pids), detectAllTmuxPanes(), detectTmuxClients()]);
+    const [ttyMap, tmuxPanes, tmuxClients] = await Promise.all([
+      getTtysForPids(pids),
+      detectAllTmuxPanes(),
+      detectTmuxClients(),
+    ]);
     // Build set of tmux session names that have at least one attached client
     const attachedTmuxSessions = new Set(tmuxClients.map((c) => c.sessionName));
     const newOrphaned = new Set<number>();
@@ -204,7 +215,15 @@ export async function discoverSessions(): Promise<ClaudeSession[]> {
   const results = await Promise.all(
     processInfos
       .filter((info) => info.workingDirectory !== null)
-      .map((info) => buildSession(info, hookStatuses.get(info.pid), claimedPaths, orphanedPids.has(info.pid), pidTmuxSession.get(info.pid) ?? null)),
+      .map((info) =>
+        buildSession(
+          info,
+          hookStatuses.get(info.pid),
+          claimedPaths,
+          orphanedPids.has(info.pid),
+          pidTmuxSession.get(info.pid) ?? null,
+        ),
+      ),
   );
 
   const sessions = results.filter((s): s is ClaudeSession => s !== null);

--- a/src/lib/git-info.ts
+++ b/src/lib/git-info.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { GitSummary } from "./types";
 import { GIT_TIMEOUT_MS } from "./constants";
+import { GitSummary } from "./types";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/lib/group-sessions.test.ts
+++ b/src/lib/group-sessions.test.ts
@@ -26,6 +26,7 @@ function makeSession(overrides: Partial<ClaudeSession> = {}): ClaudeSession {
     taskSummary: null,
     jsonlPath: null,
     prUrl: null,
+    orphaned: false,
     ...overrides,
   };
 }

--- a/src/lib/group-sessions.test.ts
+++ b/src/lib/group-sessions.test.ts
@@ -27,6 +27,7 @@ function makeSession(overrides: Partial<ClaudeSession> = {}): ClaudeSession {
     jsonlPath: null,
     prUrl: null,
     orphaned: false,
+    tmuxSession: null,
     ...overrides,
   };
 }

--- a/src/lib/group-sessions.test.ts
+++ b/src/lib/group-sessions.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { groupSessions, flattenGroupedSessions } from "./group-sessions";
+import { describe, expect, it } from "vitest";
+import { flattenGroupedSessions, groupSessions } from "./group-sessions";
 import { ClaudeSession } from "./types";
 
 function makeSession(overrides: Partial<ClaudeSession> = {}): ClaudeSession {

--- a/src/lib/hooks-installer.ts
+++ b/src/lib/hooks-installer.ts
@@ -1,7 +1,7 @@
+import { constants } from "fs";
+import { access, chmod, mkdir, readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
-import { readFile, writeFile, mkdir, chmod, access } from "fs/promises";
-import { constants } from "fs";
 
 const CLAUDE_SETTINGS_PATH = join(homedir(), ".claude", "settings.json");
 const HOOKS_DIR = join(homedir(), ".claude-control", "hooks");

--- a/src/lib/hooks-reader.ts
+++ b/src/lib/hooks-reader.ts
@@ -1,6 +1,6 @@
+import { readdir, readFile, stat, unlink } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
-import { readdir, stat, readFile, unlink } from "fs/promises";
 import { SessionStatus } from "./types";
 
 const EVENTS_DIR = join(homedir(), ".claude-control", "events");

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { workingDirToEscapedPath, escapedPathToProjectDir, workingDirToProjectDir, repoNameFromPath } from "./paths";
-import { CLAUDE_PROJECTS_DIR } from "./constants";
 import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { CLAUDE_PROJECTS_DIR } from "./constants";
+import { escapedPathToProjectDir, repoNameFromPath, workingDirToEscapedPath, workingDirToProjectDir } from "./paths";
 
 describe("workingDirToEscapedPath", () => {
   it("replaces slashes with dashes", () => {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,5 +1,5 @@
-import { CLAUDE_PROJECTS_DIR } from "./constants";
 import { join } from "path";
+import { CLAUDE_PROJECTS_DIR } from "./constants";
 
 export function workingDirToEscapedPath(workingDir: string): string {
   return workingDir.replace(/\//g, "-");

--- a/src/lib/process-utils.ts
+++ b/src/lib/process-utils.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import type { ProcessTreeEntry } from "./terminal/types";
 import { PROCESS_TIMEOUT_MS } from "./constants";
+import type { ProcessTreeEntry } from "./terminal/types";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/lib/session-meta.ts
+++ b/src/lib/session-meta.ts
@@ -1,6 +1,6 @@
-import { readFile, writeFile, mkdir, stat } from "fs/promises";
-import { join } from "path";
+import { mkdir, readFile, stat, writeFile } from "fs/promises";
 import { homedir } from "os";
+import { join } from "path";
 
 const CONFIG_DIR = join(homedir(), ".claude-control");
 const META_FILE = join(CONFIG_DIR, "session-meta.json");

--- a/src/lib/session-reader.test.ts
+++ b/src/lib/session-reader.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  extractSessionId,
-  extractStartedAt,
   extractBranch,
   extractPreview,
+  extractSessionId,
+  extractStartedAt,
   extractTaskSummary,
-  lastMessageHasError,
   hasPendingToolUse,
   isAskingForInput,
+  lastMessageHasError,
   linesToConversation,
 } from "./session-reader";
 

--- a/src/lib/session-reader.ts
+++ b/src/lib/session-reader.ts
@@ -1,14 +1,14 @@
-import { readFile, stat, open } from "fs/promises";
-import { ConversationMessage, ConversationPreview, TaskSummary, ToolInfo } from "./types";
+import { open, readFile, stat } from "fs/promises";
 import {
-  JSONL_TAIL_LINES,
-  JSONL_HEAD_LINES,
   HEAD_CHUNK_BYTES_PER_LINE,
-  TAIL_CHUNK_BYTES_PER_LINE,
+  JSONL_HEAD_LINES,
+  JSONL_TAIL_LINES,
   PREVIEW_TEXT_MAX_LENGTH,
-  TASK_TITLE_MAX_LENGTH,
+  TAIL_CHUNK_BYTES_PER_LINE,
   TASK_DESCRIPTION_MAX_LENGTH,
+  TASK_TITLE_MAX_LENGTH,
 } from "./constants";
+import { ConversationMessage, ConversationPreview, TaskSummary, ToolInfo } from "./types";
 
 interface JsonlLine {
   type: string;

--- a/src/lib/status-classifier.test.ts
+++ b/src/lib/status-classifier.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { classifyStatus } from "./status-classifier";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APPROVAL_SETTLE_MS, WORKING_THRESHOLD_MS } from "./constants";
+import { classifyStatus } from "./status-classifier";
 
 function makeInput(
   overrides: Partial<{

--- a/src/lib/status-classifier.ts
+++ b/src/lib/status-classifier.ts
@@ -1,5 +1,5 @@
-import { SessionStatus } from "./types";
 import { APPROVAL_SETTLE_MS, WORKING_THRESHOLD_MS } from "./constants";
+import { SessionStatus } from "./types";
 
 interface ClassifyInput {
   pid: number | null;

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -15,11 +15,11 @@ describe("adapter registry", () => {
 
     for (const app of knownApps) {
       const adapter = getAdapter(app);
-      expect(adapter).toBeDefined();
-      expect(typeof adapter.focus).toBe("function");
-      expect(typeof adapter.sendText).toBe("function");
-      expect(typeof adapter.sendKeystroke).toBe("function");
-      expect(typeof adapter.createSession).toBe("function");
+      expect(adapter).not.toBeNull();
+      expect(typeof adapter!.focus).toBe("function");
+      expect(typeof adapter!.sendText).toBe("function");
+      expect(typeof adapter!.sendKeystroke).toBe("function");
+      expect(typeof adapter!.createSession).toBe("function");
     }
   });
 

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -23,9 +23,9 @@ describe("adapter registry", () => {
     }
   });
 
-  it("throws for unknown terminal", async () => {
+  it("returns null for unknown terminal", async () => {
     const { getAdapter } = await import("./adapters/registry");
-    expect(() => getAdapter("unknown")).toThrow("No adapter for terminal: unknown");
+    expect(getAdapter("unknown")).toBeNull();
   });
 
   it("allows registering a custom adapter", async () => {
@@ -37,8 +37,8 @@ describe("adapter registry", () => {
       createSession: vi.fn(),
     };
 
-    // Should throw before registration
-    expect(() => getAdapter("unknown")).toThrow();
+    // Should return null before registration
+    expect(getAdapter("unknown")).toBeNull();
 
     registerAdapter("unknown", mockAdapter);
     expect(getAdapter("unknown")).toBe(mockAdapter);

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TerminalApp } from "./types";
 
 // ── Registry tests ──────────────────────────────────────────────────────────

--- a/src/lib/terminal/adapters.ts
+++ b/src/lib/terminal/adapters.ts
@@ -28,6 +28,7 @@ export async function focusSession(info: TerminalInfo): Promise<void> {
   const effectiveInfo = info.inTmux && info.tmux?.clientTty ? { ...info, tty: info.tmux.clientTty } : info;
 
   const adapter = getAdapter(effectiveInfo.app);
+  if (!adapter) return; // Unknown terminal — nothing to focus
   await adapter.focus(effectiveInfo);
 }
 
@@ -41,6 +42,7 @@ export async function sendText(info: TerminalInfo, text: string): Promise<void> 
   }
 
   const adapter = getAdapter(info.app);
+  if (!adapter) return;
   await adapter.sendText(info, text);
 }
 
@@ -62,6 +64,7 @@ export async function sendKeystroke(info: TerminalInfo, keystroke: string): Prom
   }
 
   const adapter = getAdapter(info.app);
+  if (!adapter) return;
   await adapter.sendKeystroke(info, keystroke);
 }
 
@@ -124,6 +127,7 @@ export async function createSession(opts: CreateSessionPublicOpts): Promise<void
   }
 
   const adapter = getAdapter(terminalApp);
+  if (!adapter) throw new Error(`No adapter for terminal: ${terminalApp}`);
   await adapter.createSession(effectiveCommand, { openIn, useTmux, tmuxSession, cwd, prompt });
 }
 

--- a/src/lib/terminal/adapters.ts
+++ b/src/lib/terminal/adapters.ts
@@ -1,16 +1,15 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import type { TerminalInfo, TerminalApp } from "./types";
-import { detectTmuxClients, buildProcessTree, findTerminalInTree } from "./detect";
 import { PROCESS_TIMEOUT_MS } from "../constants";
 import { getAdapter } from "./adapters/registry";
 import { shellEscape, shellEscapeDouble } from "./adapters/shared";
+import { buildProcessTree, detectTmuxClients, findTerminalInTree } from "./detect";
+import type { TerminalApp, TerminalInfo } from "./types";
 
 const execFileAsync = promisify(execFile);
 
-export type { CreateSessionOpts } from "./adapters/types";
-export type { TerminalAdapter } from "./adapters/types";
 export { getAdapter, registerAdapter } from "./adapters/registry";
+export type { CreateSessionOpts, TerminalAdapter } from "./adapters/types";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Public API — handles tmux cross-cutting logic, then delegates to adapters

--- a/src/lib/terminal/adapters/generic.ts
+++ b/src/lib/terminal/adapters/generic.ts
@@ -1,15 +1,15 @@
+import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
 import type { TerminalInfo } from "../types";
-import type { TerminalAdapter, CreateSessionOpts } from "./types";
 import {
-  execFileAsync,
-  OSASCRIPT_TIMEOUT_MS,
   escapeForAppleScript,
+  execFileAsync,
+  genericActivateScript,
   mapKeystrokeToSystemEvents,
+  OSASCRIPT_TIMEOUT_MS,
   systemEventsScript,
   withFocusDelay,
-  genericActivateScript,
 } from "./shared";
-import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
+import type { CreateSessionOpts, TerminalAdapter } from "./types";
 
 /**
  * Base adapter for terminals that use `open -a` for focus and System Events

--- a/src/lib/terminal/adapters/iterm.ts
+++ b/src/lib/terminal/adapters/iterm.ts
@@ -1,14 +1,14 @@
+import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
 import type { TerminalInfo } from "../types";
-import type { TerminalAdapter, CreateSessionOpts } from "./types";
 import {
-  execFileAsync,
-  OSASCRIPT_TIMEOUT_MS,
   escapeForAppleScript,
+  execFileAsync,
   mapKeystrokeToSystemEvents,
+  OSASCRIPT_TIMEOUT_MS,
   systemEventsScript,
   withFocusDelay,
 } from "./shared";
-import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
+import type { CreateSessionOpts, TerminalAdapter } from "./types";
 
 function focusScript(ttyPath: string): string {
   const safeTty = escapeForAppleScript(ttyPath);

--- a/src/lib/terminal/adapters/kitty.ts
+++ b/src/lib/terminal/adapters/kitty.ts
@@ -1,9 +1,9 @@
-import { readdirSync } from "fs";
 import { spawn } from "child_process";
+import { readdirSync } from "fs";
 import type { TerminalInfo } from "../types";
-import type { TerminalAdapter, CreateSessionOpts } from "./types";
-import { execFileAsync, OSASCRIPT_TIMEOUT_MS } from "./shared";
 import { createGenericAdapter } from "./generic";
+import { execFileAsync, OSASCRIPT_TIMEOUT_MS } from "./shared";
+import type { CreateSessionOpts, TerminalAdapter } from "./types";
 
 // ── kitten @ ls response types ──────────────────────────────────────────────
 // Partial types for the JSON returned by `kitten @ ls`. Only the fields we

--- a/src/lib/terminal/adapters/registry.ts
+++ b/src/lib/terminal/adapters/registry.ts
@@ -18,12 +18,8 @@ const adapters: Partial<Record<TerminalApp, TerminalAdapter>> = {
   warp: warpAdapter,
 };
 
-export function getAdapter(app: TerminalApp): TerminalAdapter {
-  const adapter = adapters[app];
-  if (!adapter) {
-    throw new Error(`No adapter for terminal: ${app}`);
-  }
-  return adapter;
+export function getAdapter(app: TerminalApp): TerminalAdapter | null {
+  return adapters[app] ?? null;
 }
 
 /** Register a new terminal adapter at runtime. */

--- a/src/lib/terminal/adapters/registry.ts
+++ b/src/lib/terminal/adapters/registry.ts
@@ -1,12 +1,12 @@
 import type { TerminalApp } from "../types";
-import type { TerminalAdapter } from "./types";
-import { itermAdapter } from "./iterm";
-import { terminalAppAdapter } from "./terminal-app";
-import { ghosttyAdapter } from "./ghostty";
-import { kittyAdapter } from "./kitty";
-import { weztermAdapter } from "./wezterm";
 import { alacrittyAdapter } from "./alacritty";
+import { ghosttyAdapter } from "./ghostty";
+import { itermAdapter } from "./iterm";
+import { kittyAdapter } from "./kitty";
+import { terminalAppAdapter } from "./terminal-app";
+import type { TerminalAdapter } from "./types";
 import { warpAdapter } from "./warp";
+import { weztermAdapter } from "./wezterm";
 
 const adapters: Partial<Record<TerminalApp, TerminalAdapter>> = {
   iterm: itermAdapter,

--- a/src/lib/terminal/adapters/terminal-app.ts
+++ b/src/lib/terminal/adapters/terminal-app.ts
@@ -1,14 +1,14 @@
+import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
 import type { TerminalInfo } from "../types";
-import type { TerminalAdapter, CreateSessionOpts } from "./types";
 import {
-  execFileAsync,
-  OSASCRIPT_TIMEOUT_MS,
   escapeForAppleScript,
+  execFileAsync,
   mapKeystrokeToSystemEvents,
+  OSASCRIPT_TIMEOUT_MS,
   systemEventsScript,
   withFocusDelay,
 } from "./shared";
-import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
+import type { CreateSessionOpts, TerminalAdapter } from "./types";
 
 function focusScript(ttyPath: string): string {
   const safeTty = escapeForAppleScript(ttyPath);

--- a/src/lib/terminal/adapters/warp.ts
+++ b/src/lib/terminal/adapters/warp.ts
@@ -1,15 +1,15 @@
+import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
 import type { TerminalInfo } from "../types";
-import type { TerminalAdapter, CreateSessionOpts } from "./types";
 import {
-  execFileAsync,
-  OSASCRIPT_TIMEOUT_MS,
   escapeForAppleScript,
+  execFileAsync,
+  genericActivateScript,
   mapKeystrokeToSystemEvents,
+  OSASCRIPT_TIMEOUT_MS,
   systemEventsScript,
   withFocusDelay,
-  genericActivateScript,
 } from "./shared";
-import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
+import type { CreateSessionOpts, TerminalAdapter } from "./types";
 
 export const warpAdapter: TerminalAdapter = {
   async focus(): Promise<void> {

--- a/src/lib/terminal/detect.test.ts
+++ b/src/lib/terminal/detect.test.ts
@@ -173,12 +173,20 @@ describe("isOrphaned", () => {
     expect(isOrphaned(100, tree, false)).toBe(true);
   });
 
-  it("returns false when session is in tmux (even without terminal ancestor)", () => {
+  it("returns false when session is in tmux with attached client", () => {
     const tree = new Map<number, ProcessTreeEntry>([
       [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
       [200, { ppid: 1, cpuPercent: 0, comm: "zsh" }],
     ]);
-    expect(isOrphaned(100, tree, true)).toBe(false);
+    expect(isOrphaned(100, tree, true, true)).toBe(false);
+  });
+
+  it("returns true when session is in tmux but detached (no client)", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
+      [200, { ppid: 1, cpuPercent: 0, comm: "zsh" }],
+    ]);
+    expect(isOrphaned(100, tree, true, false)).toBe(true);
   });
 
   it("returns false when pid is not in the tree", () => {

--- a/src/lib/terminal/detect.test.ts
+++ b/src/lib/terminal/detect.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { findTerminalInTree, matchTerminal, findClaudePidsFromTree, isOrphaned } from "./detect";
+import { describe, expect, it } from "vitest";
+import { findClaudePidsFromTree, findTerminalInTree, isOrphaned, matchTerminal } from "./detect";
 import type { ProcessTreeEntry } from "./types";
 
 describe("matchTerminal", () => {

--- a/src/lib/terminal/detect.test.ts
+++ b/src/lib/terminal/detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findTerminalInTree, matchTerminal, findClaudePidsFromTree } from "./detect";
+import { findTerminalInTree, matchTerminal, findClaudePidsFromTree, isOrphaned } from "./detect";
 import type { ProcessTreeEntry } from "./types";
 
 describe("matchTerminal", () => {
@@ -152,5 +152,55 @@ describe("findClaudePidsFromTree", () => {
   it("does not match partial names like claude-code", () => {
     const tree = new Map<number, ProcessTreeEntry>([[100, { ppid: 50, comm: "claude-code", cpuPercent: 0 }]]);
     expect(findClaudePidsFromTree(tree)).toHaveLength(0);
+  });
+});
+
+describe("isOrphaned", () => {
+  it("returns false when a known terminal is in the ancestor chain", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
+      [200, { ppid: 300, cpuPercent: 0, comm: "zsh" }],
+      [300, { ppid: 1, cpuPercent: 1, comm: "iTerm2" }],
+    ]);
+    expect(isOrphaned(100, tree, false)).toBe(false);
+  });
+
+  it("returns true when no known terminal is in the ancestor chain", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
+      [200, { ppid: 1, cpuPercent: 0, comm: "zsh" }],
+    ]);
+    expect(isOrphaned(100, tree, false)).toBe(true);
+  });
+
+  it("returns false when session is in tmux (even without terminal ancestor)", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
+      [200, { ppid: 1, cpuPercent: 0, comm: "zsh" }],
+    ]);
+    expect(isOrphaned(100, tree, true)).toBe(false);
+  });
+
+  it("returns false when pid is not in the tree", () => {
+    const tree = new Map<number, ProcessTreeEntry>();
+    expect(isOrphaned(999, tree, false)).toBe(false);
+  });
+
+  it("returns false when sshd is in the ancestor chain (SSH session)", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
+      [200, { ppid: 300, cpuPercent: 0, comm: "bash" }],
+      [300, { ppid: 1, cpuPercent: 0, comm: "sshd" }],
+    ]);
+    expect(isOrphaned(100, tree, false)).toBe(false);
+  });
+
+  it("returns true when ancestor chain ends at launchd (PID 1) with no terminal", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 200, cpuPercent: 5, comm: "claude" }],
+      [200, { ppid: 1, cpuPercent: 0, comm: "zsh" }],
+      [1, { ppid: 0, cpuPercent: 0, comm: "launchd" }],
+    ]);
+    expect(isOrphaned(100, tree, false)).toBe(true);
   });
 });

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import type { TerminalApp, TerminalInfo, TmuxPaneInfo, TmuxClientInfo, ProcessTreeEntry } from "./types";
 import { PROCESS_TIMEOUT_MS } from "../constants";
+import type { ProcessTreeEntry, TerminalApp, TerminalInfo, TmuxClientInfo, TmuxPaneInfo } from "./types";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -295,13 +295,20 @@ const NON_ORPHAN_ANCESTORS = new Set(["sshd", "ssh"]);
  * Check if a claude process is orphaned — its parent terminal has been closed.
  * Walks the process tree upward looking for a known terminal. If none is found
  * and the session is not in tmux or SSH, it's orphaned.
+ *
+ * For tmux sessions, checks if the tmux session has an attached client.
+ * A detached tmux session (no clients) is considered orphaned.
  */
 export function isOrphaned(
   pid: number,
   processTree: Map<number, ProcessTreeEntry>,
   inTmux: boolean,
+  tmuxSessionHasClient?: boolean,
 ): boolean {
-  if (inTmux) return false;
+  // In tmux with an attached client — not orphaned
+  if (inTmux && tmuxSessionHasClient) return false;
+  // In tmux but detached — orphaned
+  if (inTmux && !tmuxSessionHasClient) return true;
   if (!processTree.has(pid)) return false;
 
   // Check for known terminal

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -288,6 +288,41 @@ export async function detectTerminal(
   }
 }
 
+/** Process names that indicate a remote/non-GUI session (not orphaned). */
+const NON_ORPHAN_ANCESTORS = new Set(["sshd", "ssh"]);
+
+/**
+ * Check if a claude process is orphaned — its parent terminal has been closed.
+ * Walks the process tree upward looking for a known terminal. If none is found
+ * and the session is not in tmux or SSH, it's orphaned.
+ */
+export function isOrphaned(
+  pid: number,
+  processTree: Map<number, ProcessTreeEntry>,
+  inTmux: boolean,
+): boolean {
+  if (inTmux) return false;
+  if (!processTree.has(pid)) return false;
+
+  // Check for known terminal
+  const result = findTerminalInTree(pid, processTree);
+  if (result.app !== "unknown") return false;
+
+  // Check for non-GUI ancestors (SSH, etc.) — these aren't orphaned, just remote
+  let currentPid = pid;
+  const visited = new Set<number>();
+  while (currentPid > 1 && !visited.has(currentPid)) {
+    visited.add(currentPid);
+    const entry = processTree.get(currentPid);
+    if (!entry) break;
+    const basename = entry.comm.includes("/") ? entry.comm.split("/").pop() || entry.comm : entry.comm;
+    if (NON_ORPHAN_ANCESTORS.has(basename.toLowerCase())) return false;
+    currentPid = entry.ppid;
+  }
+
+  return true;
+}
+
 /**
  * Return the display name for a TerminalApp value.
  */

--- a/src/lib/terminal/index.ts
+++ b/src/lib/terminal/index.ts
@@ -1,31 +1,29 @@
-export type {
-  TerminalApp,
-  TerminalOpenIn,
-  TerminalInfo,
-  TmuxPaneInfo,
-  TmuxClientInfo,
-  ProcessTreeEntry,
-} from "./types";
-
+export type { CreateSessionPublicOpts as CreateSessionOpts } from "./adapters";
+export {
+  createSession,
+  focusSession,
+  listTmuxSessions,
+  sendKeystroke,
+  sendText,
+} from "./adapters";
 export {
   buildProcessTree,
+  detectAllTmuxPanes,
+  detectTerminal,
+  detectTmuxClients,
+  evictStaleTerminalCache,
   findClaudePidsFromTree,
+  findTerminalInTree,
+  getTerminalAppName,
   getTtyForPid,
   getTtysForPids,
-  detectAllTmuxPanes,
-  detectTmuxClients,
-  detectTerminal,
-  findTerminalInTree,
   matchTerminal,
-  evictStaleTerminalCache,
-  getTerminalAppName,
 } from "./detect";
-
-export {
-  focusSession,
-  sendText,
-  sendKeystroke,
-  createSession,
-  listTmuxSessions,
-} from "./adapters";
-export type { CreateSessionPublicOpts as CreateSessionOpts } from "./adapters";
+export type {
+  ProcessTreeEntry,
+  TerminalApp,
+  TerminalInfo,
+  TerminalOpenIn,
+  TmuxClientInfo,
+  TmuxPaneInfo,
+} from "./types";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,7 @@ export interface ClaudeSession {
   hasPendingToolUse: boolean;
   jsonlPath: string | null;
   prUrl: string | null;
+  orphaned: boolean;
 }
 
 export interface GitSummary {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface ClaudeSession {
   jsonlPath: string | null;
   prUrl: string | null;
   orphaned: boolean;
+  tmuxSession: string | null;
 }
 
 export interface GitSummary {


### PR DESCRIPTION
## Summary
- **README update**: Move WezTerm from basic to full terminal support, note kitty's tmux-in-kitty matching
- **Orphaned session detection**: Detect Claude CLI sessions whose parent terminal has been closed (30s throttled check via process tree walking)
- **Detached tmux detection**: Sessions in tmux with no attached client are flagged as orphaned
- **Kill button**: Orphaned sessions show an orange "Orphaned" badge and a kill button (SIGTERM/SIGKILL via new `/api/sessions/kill` endpoint)
- **Tmux reattach**: Orphaned tmux sessions also show a green reattach button that opens a new terminal tab attached to the detached session
- **Graceful unknown terminal handling**: `getAdapter()` returns null instead of throwing for unknown terminals, preventing crashes when focusing orphaned sessions

## Risk areas
- The `isOrphaned()` function walks the process tree — false positives are possible for unusual process hierarchies (SSH sessions are explicitly handled)
- The 30s orphan check interval means there's a delay before orphaned sessions are detected
- The tmux reattach endpoint opens a new terminal tab using the user's configured terminal adapter — behavior varies by terminal
- `getAdapter()` return type changed from `TerminalAdapter` to `TerminalAdapter | null` — all call sites updated but external consumers (if any) would need updating

## Test plan
- [x] Close a terminal with a running Claude session, verify "Orphaned" badge appears within 30s
- [x] Click kill button on orphaned session, verify process is terminated and card disappears
- [x] Detach a tmux session (close terminal), verify reattach button appears
- [x] Click reattach button, verify new terminal tab opens with tmux session attached
- [x] Verify non-orphaned sessions are unaffected (no badge, normal focus button)
- [x] Run `npm test` — all 135 tests pass
- [x] Run `npm run typecheck` — clean