### PR TITLE
Configurable claude command for session launch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-control",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-control",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "next": "^16.2.0",

--- a/src/app/api/sessions/create/route.ts
+++ b/src/app/api/sessions/create/route.ts
@@ -78,6 +78,7 @@ async function openTerminalWithClaude(
     tmuxSession,
     cwd,
     prompt,
+    initialCommand: config.initialCommand,
   });
 }
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -136,6 +136,7 @@ export async function PUT(request: Request) {
       terminalOpenIn: body.terminalOpenIn ?? current.terminalOpenIn,
       terminalUseTmux: body.terminalUseTmux ?? current.terminalUseTmux,
       terminalTmuxMode: body.terminalTmuxMode ?? current.terminalTmuxMode,
+      initialCommand: body.initialCommand !== undefined ? body.initialCommand : current.initialCommand,
       initialPrompt: body.initialPrompt !== undefined ? body.initialPrompt : current.initialPrompt,
       createPrPrompt: body.createPrPrompt !== undefined ? body.createPrPrompt : current.createPrPrompt,
       defaultBaseBranch: body.defaultBaseBranch ?? current.defaultBaseBranch,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -34,6 +34,7 @@ interface SettingsData {
     terminalOpenIn: string;
     terminalUseTmux: boolean;
     terminalTmuxMode: string;
+    initialCommand: string;
     initialPrompt: string;
     createPrPrompt: string;
     defaultBaseBranch: string;
@@ -122,9 +123,11 @@ export default function SettingsPage() {
   const [saved, setSaved] = useState(false);
   const [addingDir, setAddingDir] = useState(false);
   const [targetScreen, setTargetScreen] = useState<number | null>(null);
+  const [commandDraft, setCommandDraft] = useState<string | null>(null);
   const [promptDraft, setPromptDraft] = useState<string | null>(null);
   const [prPromptDraft, setPrPromptDraft] = useState<string | null>(null);
   const [baseBranchDraft, setBaseBranchDraft] = useState<string | null>(null);
+  const commandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const promptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prPromptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const baseBranchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -139,6 +142,7 @@ export default function SettingsPage() {
       .then((r) => r.json())
       .then((d: SettingsData) => {
         setData(d);
+        setCommandDraft(d.config.initialCommand ?? "claude");
         setPromptDraft(d.config.initialPrompt ?? "");
         setPrPromptDraft(d.config.createPrPrompt ?? "");
         setBaseBranchDraft(d.config.defaultBaseBranch ?? "main");
@@ -164,6 +168,18 @@ export default function SettingsPage() {
       console.error("Failed to save:", err);
     }
   };
+
+  const saveCommandDebounced = useCallback(
+    (value: string) => {
+      setCommandDraft(value);
+      if (commandTimerRef.current) clearTimeout(commandTimerRef.current);
+      commandTimerRef.current = setTimeout(() => {
+        save({ initialCommand: value });
+      }, 500);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- save is intentionally excluded (unstable reference)
+    [data],
+  );
 
   const savePromptDebounced = useCallback(
     (value: string) => {
@@ -204,6 +220,7 @@ export default function SettingsPage() {
   // Flush pending saves on unmount
   useEffect(() => {
     return () => {
+      if (commandTimerRef.current) clearTimeout(commandTimerRef.current);
       if (promptTimerRef.current) clearTimeout(promptTimerRef.current);
       if (prPromptTimerRef.current) clearTimeout(prPromptTimerRef.current);
       if (baseBranchTimerRef.current) clearTimeout(baseBranchTimerRef.current);
@@ -425,6 +442,20 @@ export default function SettingsPage() {
       <section className="mb-10">
         <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-3">Session Defaults</h2>
         <div className="rounded-xl border border-white/6 bg-[#0a0a0f]/80 px-5 py-4 space-y-5">
+          <div>
+            <h3 className="text-sm font-medium text-zinc-200">Claude Command</h3>
+            <p className="text-xs text-zinc-500 mt-0.5 mb-2">
+              Command used to launch Claude sessions. Add flags like{" "}
+              <code className="text-zinc-400">--permission-mode auto</code> to customize behavior.
+            </p>
+            <input
+              type="text"
+              value={commandDraft ?? "claude"}
+              onChange={(e) => saveCommandDebounced(e.target.value)}
+              placeholder="claude"
+              className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-700/50 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-hidden focus:border-zinc-600 transition-colors font-(family-name:--font-geist-mono)"
+            />
+          </div>
           <div>
             <h3 className="text-sm font-medium text-zinc-200">Initial Prompt</h3>
             <p className="text-xs text-zinc-500 mt-0.5 mb-2">

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,7 @@ export interface AppConfig {
   terminalOpenIn: TerminalOpenIn;
   terminalUseTmux: boolean;
   terminalTmuxMode: "per-project" | "choose";
+  initialCommand: string;
   initialPrompt: string;
   createPrPrompt: string;
   defaultBaseBranch: string;
@@ -90,6 +91,7 @@ const DEFAULT_CONFIG: AppConfig = {
   terminalOpenIn: "tab",
   terminalUseTmux: false,
   terminalTmuxMode: "per-project",
+  initialCommand: "claude",
   initialPrompt: DEFAULT_INITIAL_PROMPT,
   createPrPrompt: DEFAULT_CREATE_PR_PROMPT,
   defaultBaseBranch: "main",

--- a/src/lib/terminal/adapters.ts
+++ b/src/lib/terminal/adapters.ts
@@ -78,13 +78,14 @@ export interface CreateSessionPublicOpts {
   tmuxSession?: string;
   cwd: string;
   prompt?: string;
+  initialCommand?: string;
 }
 
 export async function createSession(opts: CreateSessionPublicOpts): Promise<void> {
-  const { terminalApp, openIn, useTmux, tmuxSession, cwd, prompt } = opts;
+  const { terminalApp, openIn, useTmux, tmuxSession, cwd, prompt, initialCommand } = opts;
 
   // Build the shell command with proper escaping
-  let command = "claude";
+  let command = initialCommand || "claude";
   if (prompt) {
     command += ` '${shellEscape(prompt)}'`;
   }


### PR DESCRIPTION
## Summary
- Adds an `initialCommand` config option (defaults to `"claude"`) so users can customize the CLI command used when launching sessions
- Enables passing flags like `--permission-mode auto` or `--model sonnet` to all new sessions
- New "Claude Command" input field in Settings > Session Defaults

## Risk areas
- The command string is used directly in shell execution — existing `shellEscape` handles the prompt portion, but the command itself is trusted from user config (same as other config values like `terminalApp`)

## Test plan
- [x] Verify default behavior unchanged — leave setting empty/default, launch a session, confirm it runs `claude`
- [x] Set command to `claude --permission-mode auto`, create a session, confirm Claude launches in auto mode
- [x] Verify the setting persists across app restarts
- [x] Verify the field appears correctly in Settings page under Session Defaults