### PR TITLE
fix: address security vulnerabilities reported in #36

### DIFF
--- a/src/app/api/actions/open/route.ts
+++ b/src/app/api/actions/open/route.ts
@@ -11,6 +11,7 @@ import {
   sendKeystroke,
   sendText,
 } from "@/lib/terminal";
+import { escapeForAppleScript } from "@/lib/terminal/adapters/shared";
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -171,7 +172,7 @@ export async function POST(request: Request) {
         }
         const browserConfig = await loadConfig();
         const browserDef = BROWSER_OPTIONS.find((b) => b.id === browserConfig.browser) ?? BROWSER_OPTIONS[0];
-        const escapedUrl = url.replace(/"/g, '\\"');
+        const escapedUrl = escapeForAppleScript(url);
 
         const chromiumBrowsers = ["Google Chrome", "Arc", "Brave Browser", "Microsoft Edge"];
         if (chromiumBrowsers.includes(browserDef.appName)) {

--- a/src/app/api/sessions/cleanup/route.ts
+++ b/src/app/api/sessions/cleanup/route.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { NextResponse } from "next/server";
 import { promisify } from "util";
+import { isClaudeProcess } from "@/lib/process-utils";
 
 const execFileAsync = promisify(execFile);
 
@@ -10,6 +11,7 @@ interface CleanupRequest {
 }
 
 async function killProcess(pid: number): Promise<void> {
+  if (!(await isClaudeProcess(pid))) return;
   try {
     process.kill(pid, "SIGTERM");
     // Give it a moment to exit gracefully

--- a/src/app/api/sessions/create/route.ts
+++ b/src/app/api/sessions/create/route.ts
@@ -91,6 +91,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Missing repoPath" }, { status: 400 });
     }
 
+    if (branchName && !/^[a-zA-Z0-9._\/-]+$/.test(branchName)) {
+      return NextResponse.json({ error: "Invalid branch name" }, { status: 400 });
+    }
+
+    if (branchName && (branchName.includes("..") || branchName.startsWith("/") || branchName.endsWith("/"))) {
+      return NextResponse.json({ error: "Invalid branch name" }, { status: 400 });
+    }
+
     // Verify the repo exists
     try {
       await stat(repoPath);

--- a/src/app/api/sessions/kill/route.ts
+++ b/src/app/api/sessions/kill/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { isClaudeProcess } from "@/lib/process-utils";
 
 export async function POST(request: Request) {
   try {
@@ -6,6 +7,10 @@ export async function POST(request: Request) {
 
     if (!pid || typeof pid !== "number") {
       return NextResponse.json({ error: "Missing or invalid pid" }, { status: 400 });
+    }
+
+    if (!(await isClaudeProcess(pid))) {
+      return NextResponse.json({ error: "PID is not a claude process" }, { status: 403 });
     }
 
     try {

--- a/src/app/api/sessions/reattach/route.ts
+++ b/src/app/api/sessions/reattach/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { loadConfig } from "@/lib/config";
 import { getAdapter } from "@/lib/terminal/adapters/registry";
+import { shellEscape } from "@/lib/terminal/adapters/shared";
 import type { TerminalApp } from "@/lib/terminal/types";
 
 export async function POST(request: Request) {
@@ -20,7 +21,7 @@ export async function POST(request: Request) {
     }
 
     // Open a new terminal tab that attaches to the detached tmux session
-    await adapter.createSession(`tmux attach -t '${tmuxSession}'`, {
+    await adapter.createSession(`tmux attach -t '${shellEscape(tmuxSession)}'`, {
       openIn: config.terminalOpenIn ?? "tab",
       useTmux: false,
       cwd: cwd || "/tmp",

--- a/src/lib/git-info.ts
+++ b/src/lib/git-info.ts
@@ -74,10 +74,13 @@ export async function getPrUrl(cwd: string, branch: string): Promise<string | nu
   if (cached) return cached.url;
 
   try {
-    const { stdout } = await execFileAsync("gh", ["pr", "view", branch, "--json", "url", "--jq", ".url"], {
-      cwd,
-      timeout: 5000,
-    });
+    // Use `gh pr list --head` instead of `gh pr view` because the latter
+    // interprets numeric branch names (e.g. "36") as PR numbers.
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["pr", "list", "--head", branch, "--json", "url", "--jq", ".[0].url", "--state", "open", "--limit", "1"],
+      { cwd, timeout: 5000 },
+    );
     const url = stdout.trim() || null;
     prUrlCache.set(cacheKey, { url, ts: Date.now() });
     return url;

--- a/src/lib/process-utils.ts
+++ b/src/lib/process-utils.ts
@@ -40,6 +40,21 @@ export async function getBatchWorkingDirectories(pids: number[]): Promise<Map<nu
 }
 
 /**
+ * Check whether a PID belongs to a "claude" process.
+ * Returns true only when the process exists and its command name is "claude".
+ */
+export async function isClaudeProcess(pid: number): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("ps", ["-o", "comm=", "-p", String(pid)], {
+      timeout: PROCESS_TIMEOUT_MS,
+    });
+    return stdout.trim() === "claude";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build ProcessInfo for all given PIDs using the process tree + one lsof call.
  * The tree (from buildProcessTree) provides comm and %cpu; lsof provides cwds.
  * Since findClaudePidsFromTree already filters by `comm === "claude"`, the

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Reject cross-origin requests to API routes.
+ *
+ * Without this, any website the user visits could make fetch() calls to
+ * localhost:3200 and hit state-changing endpoints (kill processes, delete
+ * branches, send text to terminals, etc.).
+ *
+ * We allow requests that either:
+ * - Have no Origin header (same-origin navigations, curl, Electron webview)
+ * - Have an Origin matching the local server
+ */
+export function middleware(request: NextRequest) {
+  const origin = request.headers.get("origin");
+
+  if (origin) {
+    const allowedOrigins = [`http://localhost:3200`, `http://127.0.0.1:3200`];
+    if (!allowedOrigins.includes(origin)) {
+      return NextResponse.json({ error: "Forbidden: cross-origin request" }, { status: 403 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/api/:path*",
+};


### PR DESCRIPTION
## Summary
- Add CSRF protection via Origin header check middleware — rejects cross-origin requests to all API routes
- Validate PIDs belong to a `claude` process before sending SIGTERM/SIGKILL in kill and cleanup endpoints
- Fix command injection via tmux session name by applying `shellEscape()` in the reattach route
- Validate branch names against a safe character set and reject path traversal patterns (`..`, leading/trailing slashes)
- Use the existing `escapeForAppleScript()` helper for URL interpolation in the open-url action

## Risk areas
- **PID validation (fix #2)** changes observable behavior: previously, killing a stale/non-claude PID silently succeeded; now it returns 403. If the UI surfaces this as an error on already-dead sessions, we may want to soften the response.
- **CSRF middleware (fix #1)** blocks any request with a non-localhost `Origin` header. Electron webview requests should be unaffected (same-origin or no Origin), but worth verifying on both dev and packaged builds.

## Test plan
- [x] Dashboard loads and all API polling still works with the middleware in place
- [x] Kill a running session from the UI — works as before
- [x] Create a worktree session with a normal branch name — succeeds
- [x] Open a PR URL from the UI (Chromium browser path) — tab focus/open still works
- [x] If using tmux mode: detach and reattach a session — still works
- [x] Verify CSRF block: from another site's DevTools, `fetch("http://localhost:3200/api/sessions")` returns 403

Closes #36