### PR TITLE
feat: add cmux terminal support

### DIFF
--- a/src/app/api/sessions/cleanup/route.ts
+++ b/src/app/api/sessions/cleanup/route.ts
@@ -32,13 +32,9 @@ async function findMainRepo(worktreeDir: string): Promise<string | null> {
   // Try running from the worktree directory itself first
   try {
     await stat(worktreeDir);
-    const { stdout } = await execFileAsync(
-      "git",
-      ["-C", worktreeDir, "worktree", "list", "--porcelain"],
-      {
-        timeout: 5000,
-      },
-    );
+    const { stdout } = await execFileAsync("git", ["-C", worktreeDir, "worktree", "list", "--porcelain"], {
+      timeout: 5000,
+    });
     const match = stdout.match(/^worktree (.+)$/m);
     if (match) return match[1];
   } catch {
@@ -53,13 +49,9 @@ async function findMainRepo(worktreeDir: string): Promise<string | null> {
     const candidateMain = dirMatch[1];
     try {
       await stat(candidateMain);
-      const { stdout } = await execFileAsync(
-        "git",
-        ["-C", candidateMain, "rev-parse", "--git-dir"],
-        {
-          timeout: 3000,
-        },
-      );
+      const { stdout } = await execFileAsync("git", ["-C", candidateMain, "rev-parse", "--git-dir"], {
+        timeout: 3000,
+      });
       if (stdout.trim()) return candidateMain;
     } catch {
       // Not a valid repo
@@ -81,13 +73,9 @@ async function removeWorktree(worktreeDir: string): Promise<void> {
   }
 
   // Remove the worktree (--force handles dirty working trees)
-  await execFileAsync(
-    "git",
-    ["-C", mainRepo, "worktree", "remove", worktreeDir, "--force"],
-    {
-      timeout: 10000,
-    },
-  );
+  await execFileAsync("git", ["-C", mainRepo, "worktree", "remove", worktreeDir, "--force"], {
+    timeout: 10000,
+  });
 
   // Prune any stale worktree references
   await execFileAsync("git", ["-C", mainRepo, "worktree", "prune"], {
@@ -95,17 +83,12 @@ async function removeWorktree(worktreeDir: string): Promise<void> {
   });
 }
 
-async function deleteBranch(
-  worktreeDir: string,
-  branch: string,
-): Promise<void> {
+async function deleteBranch(worktreeDir: string, branch: string): Promise<void> {
   const mainRepo = await findMainRepo(worktreeDir);
   if (!mainRepo) return;
 
   try {
-    await execFileAsync("git", ["-C", mainRepo, "branch", "-D", branch], {
-      timeout: 5000,
-    });
+    await execFileAsync("git", ["-C", mainRepo, "branch", "-D", branch], { timeout: 5000 });
   } catch {
     // Branch may already be deleted or not exist locally
   }
@@ -117,22 +100,15 @@ export async function POST(request: Request) {
     const { pid, workingDirectory } = body;
 
     if (!workingDirectory) {
-      return NextResponse.json(
-        { error: "Missing workingDirectory" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Missing workingDirectory" }, { status: 400 });
     }
 
     // Get the branch name before we tear things down
     let branch: string | null = null;
     try {
-      const { stdout } = await execFileAsync(
-        "git",
-        ["-C", workingDirectory, "rev-parse", "--abbrev-ref", "HEAD"],
-        {
-          timeout: 3000,
-        },
-      );
+      const { stdout } = await execFileAsync("git", ["-C", workingDirectory, "rev-parse", "--abbrev-ref", "HEAD"], {
+        timeout: 3000,
+      });
       branch = stdout.trim() || null;
     } catch {
       // Can't determine branch
@@ -160,9 +136,6 @@ export async function POST(request: Request) {
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : String(error);
     console.error("Cleanup failed:", msg);
-    return NextResponse.json(
-      { error: `Cleanup failed: ${msg}` },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: `Cleanup failed: ${msg}` }, { status: 500 });
   }
 }

--- a/src/app/api/sessions/cleanup/route.ts
+++ b/src/app/api/sessions/cleanup/route.ts
@@ -1,4 +1,5 @@
 import { execFile } from "child_process";
+import { stat } from "fs/promises";
 import { NextResponse } from "next/server";
 import { promisify } from "util";
 import { isClaudeProcess } from "@/lib/process-utils";
@@ -27,18 +28,44 @@ async function killProcess(pid: number): Promise<void> {
   }
 }
 
-async function removeWorktree(worktreeDir: string): Promise<void> {
-  // Find the main repo that owns this worktree
-  const { stdout } = await execFileAsync("git", ["-C", worktreeDir, "worktree", "list", "--porcelain"], {
-    timeout: 5000,
-  });
+async function findMainRepo(worktreeDir: string): Promise<string | null> {
+  // Try running from the worktree directory itself first
+  try {
+    await stat(worktreeDir);
+    const { stdout } = await execFileAsync("git", ["-C", worktreeDir, "worktree", "list", "--porcelain"], {
+      timeout: 5000,
+    });
+    const match = stdout.match(/^worktree (.+)$/m);
+    if (match) return match[1];
+  } catch {
+    // Directory doesn't exist or not a git repo — try resolving from the .git file
+  }
 
-  // First "worktree" line is the main repo
-  const match = stdout.match(/^worktree (.+)$/m);
-  if (!match) {
+  // If the directory is gone, try to infer the main repo from the path.
+  // Worktrees created by claude-control are siblings: <parent>/<repo>-<branch>
+  // The main repo is <parent>/<repo>.
+  const dirMatch = worktreeDir.match(/^(.+\/([^/]+?))-[^/]+\/?$/);
+  if (dirMatch) {
+    const candidateMain = dirMatch[1];
+    try {
+      await stat(candidateMain);
+      const { stdout } = await execFileAsync("git", ["-C", candidateMain, "rev-parse", "--git-dir"], {
+        timeout: 3000,
+      });
+      if (stdout.trim()) return candidateMain;
+    } catch {
+      // Not a valid repo
+    }
+  }
+
+  return null;
+}
+
+async function removeWorktree(worktreeDir: string): Promise<void> {
+  const mainRepo = await findMainRepo(worktreeDir);
+  if (!mainRepo) {
     throw new Error("Could not determine main worktree");
   }
-  const mainRepo = match[1];
 
   // Don't delete the main repo!
   if (mainRepo === worktreeDir) {
@@ -57,13 +84,8 @@ async function removeWorktree(worktreeDir: string): Promise<void> {
 }
 
 async function deleteBranch(worktreeDir: string, branch: string): Promise<void> {
-  // Get the main repo path
-  const { stdout } = await execFileAsync("git", ["-C", worktreeDir, "worktree", "list", "--porcelain"], {
-    timeout: 5000,
-  });
-  const match = stdout.match(/^worktree (.+)$/m);
-  if (!match) return;
-  const mainRepo = match[1];
+  const mainRepo = await findMainRepo(worktreeDir);
+  if (!mainRepo) return;
 
   try {
     await execFileAsync("git", ["-C", mainRepo, "branch", "-D", branch], { timeout: 5000 });

--- a/src/app/api/sessions/cleanup/route.ts
+++ b/src/app/api/sessions/cleanup/route.ts
@@ -32,9 +32,13 @@ async function findMainRepo(worktreeDir: string): Promise<string | null> {
   // Try running from the worktree directory itself first
   try {
     await stat(worktreeDir);
-    const { stdout } = await execFileAsync("git", ["-C", worktreeDir, "worktree", "list", "--porcelain"], {
-      timeout: 5000,
-    });
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", worktreeDir, "worktree", "list", "--porcelain"],
+      {
+        timeout: 5000,
+      },
+    );
     const match = stdout.match(/^worktree (.+)$/m);
     if (match) return match[1];
   } catch {
@@ -49,9 +53,13 @@ async function findMainRepo(worktreeDir: string): Promise<string | null> {
     const candidateMain = dirMatch[1];
     try {
       await stat(candidateMain);
-      const { stdout } = await execFileAsync("git", ["-C", candidateMain, "rev-parse", "--git-dir"], {
-        timeout: 3000,
-      });
+      const { stdout } = await execFileAsync(
+        "git",
+        ["-C", candidateMain, "rev-parse", "--git-dir"],
+        {
+          timeout: 3000,
+        },
+      );
       if (stdout.trim()) return candidateMain;
     } catch {
       // Not a valid repo
@@ -73,9 +81,13 @@ async function removeWorktree(worktreeDir: string): Promise<void> {
   }
 
   // Remove the worktree (--force handles dirty working trees)
-  await execFileAsync("git", ["-C", mainRepo, "worktree", "remove", worktreeDir, "--force"], {
-    timeout: 10000,
-  });
+  await execFileAsync(
+    "git",
+    ["-C", mainRepo, "worktree", "remove", worktreeDir, "--force"],
+    {
+      timeout: 10000,
+    },
+  );
 
   // Prune any stale worktree references
   await execFileAsync("git", ["-C", mainRepo, "worktree", "prune"], {
@@ -83,12 +95,17 @@ async function removeWorktree(worktreeDir: string): Promise<void> {
   });
 }
 
-async function deleteBranch(worktreeDir: string, branch: string): Promise<void> {
+async function deleteBranch(
+  worktreeDir: string,
+  branch: string,
+): Promise<void> {
   const mainRepo = await findMainRepo(worktreeDir);
   if (!mainRepo) return;
 
   try {
-    await execFileAsync("git", ["-C", mainRepo, "branch", "-D", branch], { timeout: 5000 });
+    await execFileAsync("git", ["-C", mainRepo, "branch", "-D", branch], {
+      timeout: 5000,
+    });
   } catch {
     // Branch may already be deleted or not exist locally
   }
@@ -100,15 +117,22 @@ export async function POST(request: Request) {
     const { pid, workingDirectory } = body;
 
     if (!workingDirectory) {
-      return NextResponse.json({ error: "Missing workingDirectory" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing workingDirectory" },
+        { status: 400 },
+      );
     }
 
     // Get the branch name before we tear things down
     let branch: string | null = null;
     try {
-      const { stdout } = await execFileAsync("git", ["-C", workingDirectory, "rev-parse", "--abbrev-ref", "HEAD"], {
-        timeout: 3000,
-      });
+      const { stdout } = await execFileAsync(
+        "git",
+        ["-C", workingDirectory, "rev-parse", "--abbrev-ref", "HEAD"],
+        {
+          timeout: 3000,
+        },
+      );
       branch = stdout.trim() || null;
     } catch {
       // Can't determine branch
@@ -136,6 +160,9 @@ export async function POST(request: Request) {
   } catch (error: unknown) {
     const msg = error instanceof Error ? error.message : String(error);
     console.error("Cleanup failed:", msg);
-    return NextResponse.json({ error: `Cleanup failed: ${msg}` }, { status: 500 });
+    return NextResponse.json(
+      { error: `Cleanup failed: ${msg}` },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -18,14 +18,17 @@ const execFileAsync = promisify(execFile);
 
 export const dynamic = "force-dynamic";
 
-async function checkInstalledApps<T extends { appName: string; command?: string }>(
+async function checkInstalledApps<
+  T extends { appName: string; command?: string },
+>(
   options: T[],
   alwaysInstalled?: Set<string>,
 ): Promise<(T & { installed: boolean })[]> {
   const env = await getShellEnv();
   return Promise.all(
     options.map(async (opt) => {
-      if (!opt.appName || alwaysInstalled?.has(opt.appName)) return { ...opt, installed: true };
+      if (!opt.appName || alwaysInstalled?.has(opt.appName))
+        return { ...opt, installed: true };
       // Try macOS app bundle first, then CLI command as fallback
       const checks = [
         execFileAsync("open", ["-Ra", opt.appName], { timeout: 3000 }).then(
@@ -79,7 +82,9 @@ const DEPENDENCIES: DependencyDef[] = [
   },
 ];
 
-async function checkDependencies(): Promise<(DependencyDef & { installed: boolean })[]> {
+async function checkDependencies(): Promise<
+  (DependencyDef & { installed: boolean })[]
+> {
   const env = await getShellEnv();
   return Promise.all(
     DEPENDENCIES.map(async (dep) => {
@@ -95,14 +100,15 @@ async function checkDependencies(): Promise<(DependencyDef & { installed: boolea
 
 export async function GET() {
   try {
-    const [config, terminalApps, browsers, editors, gitGuis, dependencies] = await Promise.all([
-      loadConfig(),
-      checkInstalledApps(TERMINAL_APP_OPTIONS, new Set(["Terminal"])),
-      checkInstalledApps(BROWSER_OPTIONS, new Set(["Safari"])),
-      checkInstalledApps(EDITOR_OPTIONS),
-      checkInstalledApps(GIT_GUI_OPTIONS),
-      checkDependencies(),
-    ]);
+    const [config, terminalApps, browsers, editors, gitGuis, dependencies] =
+      await Promise.all([
+        loadConfig(),
+        checkInstalledApps(TERMINAL_APP_OPTIONS, new Set(["Terminal"])),
+        checkInstalledApps(BROWSER_OPTIONS, new Set(["Safari"])),
+        checkInstalledApps(EDITOR_OPTIONS),
+        checkInstalledApps(GIT_GUI_OPTIONS),
+        checkDependencies(),
+      ]);
 
     return NextResponse.json({
       config,
@@ -118,7 +124,10 @@ export async function GET() {
     });
   } catch (error) {
     console.error("Failed to load settings:", error);
-    return NextResponse.json({ error: "Failed to load settings" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to load settings" },
+      { status: 500 },
+    );
   }
 }
 
@@ -139,17 +148,32 @@ export async function PUT(request: Request) {
       terminalOpenIn: body.terminalOpenIn ?? current.terminalOpenIn,
       terminalUseTmux: body.terminalUseTmux ?? current.terminalUseTmux,
       terminalTmuxMode: body.terminalTmuxMode ?? current.terminalTmuxMode,
-      initialCommand: body.initialCommand !== undefined ? body.initialCommand : current.initialCommand,
-      initialPrompt: body.initialPrompt !== undefined ? body.initialPrompt : current.initialPrompt,
-      createPrPrompt: body.createPrPrompt !== undefined ? body.createPrPrompt : current.createPrPrompt,
+      initialCommand:
+        body.initialCommand !== undefined
+          ? body.initialCommand
+          : current.initialCommand,
+      initialPrompt:
+        body.initialPrompt !== undefined
+          ? body.initialPrompt
+          : current.initialPrompt,
+      createPrPrompt:
+        body.createPrPrompt !== undefined
+          ? body.createPrPrompt
+          : current.createPrPrompt,
       defaultBaseBranch: body.defaultBaseBranch ?? current.defaultBaseBranch,
-      showKeyboardHints: body.showKeyboardHints !== undefined ? body.showKeyboardHints : current.showKeyboardHints,
+      showKeyboardHints:
+        body.showKeyboardHints !== undefined
+          ? body.showKeyboardHints
+          : current.showKeyboardHints,
     };
 
     await saveConfig(updated);
     return NextResponse.json({ config: updated });
   } catch (error) {
     console.error("Failed to save settings:", error);
-    return NextResponse.json({ error: "Failed to save settings" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to save settings" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -12,6 +12,7 @@ import {
   TERMINAL_OPEN_IN_OPTIONS,
   TERMINAL_TMUX_MODE_OPTIONS,
 } from "@/lib/config";
+import { getShellEnv } from "@/lib/shell-env";
 
 const execFileAsync = promisify(execFile);
 
@@ -21,6 +22,7 @@ async function checkInstalledApps<T extends { appName: string; command?: string 
   options: T[],
   alwaysInstalled?: Set<string>,
 ): Promise<(T & { installed: boolean })[]> {
+  const env = await getShellEnv();
   return Promise.all(
     options.map(async (opt) => {
       if (!opt.appName || alwaysInstalled?.has(opt.appName)) return { ...opt, installed: true };
@@ -33,7 +35,7 @@ async function checkInstalledApps<T extends { appName: string; command?: string 
       ];
       if (opt.command) {
         checks.push(
-          execFileAsync("which", [opt.command], { timeout: 3000 }).then(
+          execFileAsync("which", [opt.command], { timeout: 3000, env }).then(
             () => true,
             () => false,
           ),
@@ -78,10 +80,11 @@ const DEPENDENCIES: DependencyDef[] = [
 ];
 
 async function checkDependencies(): Promise<(DependencyDef & { installed: boolean })[]> {
+  const env = await getShellEnv();
   return Promise.all(
     DEPENDENCIES.map(async (dep) => {
       try {
-        await execFileAsync("which", [dep.command], { timeout: 3000 });
+        await execFileAsync("which", [dep.command], { timeout: 3000, env });
         return { ...dep, installed: true };
       } catch {
         return { ...dep, installed: false };

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -18,17 +18,14 @@ const execFileAsync = promisify(execFile);
 
 export const dynamic = "force-dynamic";
 
-async function checkInstalledApps<
-  T extends { appName: string; command?: string },
->(
+async function checkInstalledApps<T extends { appName: string; command?: string }>(
   options: T[],
   alwaysInstalled?: Set<string>,
 ): Promise<(T & { installed: boolean })[]> {
   const env = await getShellEnv();
   return Promise.all(
     options.map(async (opt) => {
-      if (!opt.appName || alwaysInstalled?.has(opt.appName))
-        return { ...opt, installed: true };
+      if (!opt.appName || alwaysInstalled?.has(opt.appName)) return { ...opt, installed: true };
       // Try macOS app bundle first, then CLI command as fallback
       const checks = [
         execFileAsync("open", ["-Ra", opt.appName], { timeout: 3000 }).then(
@@ -82,9 +79,7 @@ const DEPENDENCIES: DependencyDef[] = [
   },
 ];
 
-async function checkDependencies(): Promise<
-  (DependencyDef & { installed: boolean })[]
-> {
+async function checkDependencies(): Promise<(DependencyDef & { installed: boolean })[]> {
   const env = await getShellEnv();
   return Promise.all(
     DEPENDENCIES.map(async (dep) => {
@@ -100,15 +95,14 @@ async function checkDependencies(): Promise<
 
 export async function GET() {
   try {
-    const [config, terminalApps, browsers, editors, gitGuis, dependencies] =
-      await Promise.all([
-        loadConfig(),
-        checkInstalledApps(TERMINAL_APP_OPTIONS, new Set(["Terminal"])),
-        checkInstalledApps(BROWSER_OPTIONS, new Set(["Safari"])),
-        checkInstalledApps(EDITOR_OPTIONS),
-        checkInstalledApps(GIT_GUI_OPTIONS),
-        checkDependencies(),
-      ]);
+    const [config, terminalApps, browsers, editors, gitGuis, dependencies] = await Promise.all([
+      loadConfig(),
+      checkInstalledApps(TERMINAL_APP_OPTIONS, new Set(["Terminal"])),
+      checkInstalledApps(BROWSER_OPTIONS, new Set(["Safari"])),
+      checkInstalledApps(EDITOR_OPTIONS),
+      checkInstalledApps(GIT_GUI_OPTIONS),
+      checkDependencies(),
+    ]);
 
     return NextResponse.json({
       config,
@@ -124,10 +118,7 @@ export async function GET() {
     });
   } catch (error) {
     console.error("Failed to load settings:", error);
-    return NextResponse.json(
-      { error: "Failed to load settings" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to load settings" }, { status: 500 });
   }
 }
 
@@ -148,32 +139,17 @@ export async function PUT(request: Request) {
       terminalOpenIn: body.terminalOpenIn ?? current.terminalOpenIn,
       terminalUseTmux: body.terminalUseTmux ?? current.terminalUseTmux,
       terminalTmuxMode: body.terminalTmuxMode ?? current.terminalTmuxMode,
-      initialCommand:
-        body.initialCommand !== undefined
-          ? body.initialCommand
-          : current.initialCommand,
-      initialPrompt:
-        body.initialPrompt !== undefined
-          ? body.initialPrompt
-          : current.initialPrompt,
-      createPrPrompt:
-        body.createPrPrompt !== undefined
-          ? body.createPrPrompt
-          : current.createPrPrompt,
+      initialCommand: body.initialCommand !== undefined ? body.initialCommand : current.initialCommand,
+      initialPrompt: body.initialPrompt !== undefined ? body.initialPrompt : current.initialPrompt,
+      createPrPrompt: body.createPrPrompt !== undefined ? body.createPrPrompt : current.createPrPrompt,
       defaultBaseBranch: body.defaultBaseBranch ?? current.defaultBaseBranch,
-      showKeyboardHints:
-        body.showKeyboardHints !== undefined
-          ? body.showKeyboardHints
-          : current.showKeyboardHints,
+      showKeyboardHints: body.showKeyboardHints !== undefined ? body.showKeyboardHints : current.showKeyboardHints,
     };
 
     await saveConfig(updated);
     return NextResponse.json({ config: updated });
   } catch (error) {
     console.error("Failed to save settings:", error);
-    return NextResponse.json(
-      { error: "Failed to save settings" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to save settings" }, { status: 500 });
   }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -33,48 +33,12 @@ export const DEFAULT_CREATE_PR_PROMPT =
 
 export const EDITOR_OPTIONS = [
   { id: "none", label: "None", command: "", appName: "", processName: "" },
-  {
-    id: "vscode",
-    label: "VS Code",
-    command: "code",
-    appName: "Visual Studio Code",
-    processName: "Code",
-  },
-  {
-    id: "cursor",
-    label: "Cursor",
-    command: "cursor",
-    appName: "Cursor",
-    processName: "Cursor",
-  },
-  {
-    id: "zed",
-    label: "Zed",
-    command: "zed",
-    appName: "Zed",
-    processName: "Zed",
-  },
-  {
-    id: "sublime",
-    label: "Sublime Text",
-    command: "subl",
-    appName: "Sublime Text",
-    processName: "Sublime Text",
-  },
-  {
-    id: "webstorm",
-    label: "WebStorm",
-    command: "webstorm",
-    appName: "WebStorm",
-    processName: "WebStorm",
-  },
-  {
-    id: "intellij",
-    label: "IntelliJ IDEA",
-    command: "idea",
-    appName: "IntelliJ IDEA",
-    processName: "IntelliJ IDEA",
-  },
+  { id: "vscode", label: "VS Code", command: "code", appName: "Visual Studio Code", processName: "Code" },
+  { id: "cursor", label: "Cursor", command: "cursor", appName: "Cursor", processName: "Cursor" },
+  { id: "zed", label: "Zed", command: "zed", appName: "Zed", processName: "Zed" },
+  { id: "sublime", label: "Sublime Text", command: "subl", appName: "Sublime Text", processName: "Sublime Text" },
+  { id: "webstorm", label: "WebStorm", command: "webstorm", appName: "WebStorm", processName: "WebStorm" },
+  { id: "intellij", label: "IntelliJ IDEA", command: "idea", appName: "IntelliJ IDEA", processName: "IntelliJ IDEA" },
 ];
 
 export const GIT_GUI_OPTIONS = [

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -67,6 +67,7 @@ export const TERMINAL_APP_OPTIONS = [
   { id: "wezterm", label: "WezTerm", appName: "WezTerm" },
   { id: "alacritty", label: "Alacritty", appName: "Alacritty" },
   { id: "warp", label: "Warp", appName: "Warp" },
+  { id: "cmux", label: "Cmux", appName: "Cmux" },
 ];
 
 export const TERMINAL_OPEN_IN_OPTIONS = [

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -33,12 +33,48 @@ export const DEFAULT_CREATE_PR_PROMPT =
 
 export const EDITOR_OPTIONS = [
   { id: "none", label: "None", command: "", appName: "", processName: "" },
-  { id: "vscode", label: "VS Code", command: "code", appName: "Visual Studio Code", processName: "Code" },
-  { id: "cursor", label: "Cursor", command: "cursor", appName: "Cursor", processName: "Cursor" },
-  { id: "zed", label: "Zed", command: "zed", appName: "Zed", processName: "Zed" },
-  { id: "sublime", label: "Sublime Text", command: "subl", appName: "Sublime Text", processName: "Sublime Text" },
-  { id: "webstorm", label: "WebStorm", command: "webstorm", appName: "WebStorm", processName: "WebStorm" },
-  { id: "intellij", label: "IntelliJ IDEA", command: "idea", appName: "IntelliJ IDEA", processName: "IntelliJ IDEA" },
+  {
+    id: "vscode",
+    label: "VS Code",
+    command: "code",
+    appName: "Visual Studio Code",
+    processName: "Code",
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    command: "cursor",
+    appName: "Cursor",
+    processName: "Cursor",
+  },
+  {
+    id: "zed",
+    label: "Zed",
+    command: "zed",
+    appName: "Zed",
+    processName: "Zed",
+  },
+  {
+    id: "sublime",
+    label: "Sublime Text",
+    command: "subl",
+    appName: "Sublime Text",
+    processName: "Sublime Text",
+  },
+  {
+    id: "webstorm",
+    label: "WebStorm",
+    command: "webstorm",
+    appName: "WebStorm",
+    processName: "WebStorm",
+  },
+  {
+    id: "intellij",
+    label: "IntelliJ IDEA",
+    command: "idea",
+    appName: "IntelliJ IDEA",
+    processName: "IntelliJ IDEA",
+  },
 ];
 
 export const GIT_GUI_OPTIONS = [

--- a/src/lib/process-utils.ts
+++ b/src/lib/process-utils.ts
@@ -48,7 +48,9 @@ export async function isClaudeProcess(pid: number): Promise<boolean> {
     const { stdout } = await execFileAsync("ps", ["-o", "comm=", "-p", String(pid)], {
       timeout: PROCESS_TIMEOUT_MS,
     });
-    return stdout.trim() === "claude";
+    const comm = stdout.trim();
+    const basename = comm.includes("/") ? comm.split("/").pop() || comm : comm;
+    return basename === "claude";
   } catch {
     return false;
   }

--- a/src/lib/process-utils.ts
+++ b/src/lib/process-utils.ts
@@ -17,19 +17,13 @@ export interface ProcessInfo {
  * Output format: p<pid>\nfcwd\nn<path> per process — `f` lines are
  * intentionally skipped since we only need `p` (PID) and `n` (path).
  */
-export async function getBatchWorkingDirectories(
-  pids: number[],
-): Promise<Map<number, string>> {
+export async function getBatchWorkingDirectories(pids: number[]): Promise<Map<number, string>> {
   const result = new Map<number, string>();
   if (pids.length === 0) return result;
   try {
-    const { stdout } = await execFileAsync(
-      "lsof",
-      ["-p", pids.join(","), "-Fpn", "-d", "cwd"],
-      {
-        timeout: PROCESS_TIMEOUT_MS,
-      },
-    );
+    const { stdout } = await execFileAsync("lsof", ["-p", pids.join(","), "-Fpn", "-d", "cwd"], {
+      timeout: PROCESS_TIMEOUT_MS,
+    });
     let currentPid: number | null = null;
     for (const line of stdout.split("\n")) {
       if (line.startsWith("p")) {
@@ -51,13 +45,9 @@ export async function getBatchWorkingDirectories(
  */
 export async function isClaudeProcess(pid: number): Promise<boolean> {
   try {
-    const { stdout } = await execFileAsync(
-      "ps",
-      ["-o", "comm=", "-p", String(pid)],
-      {
-        timeout: PROCESS_TIMEOUT_MS,
-      },
-    );
+    const { stdout } = await execFileAsync("ps", ["-o", "comm=", "-p", String(pid)], {
+      timeout: PROCESS_TIMEOUT_MS,
+    });
     const comm = stdout.trim();
     const basename = comm.includes("/") ? comm.split("/").pop() || comm : comm;
     return basename === "claude";

--- a/src/lib/process-utils.ts
+++ b/src/lib/process-utils.ts
@@ -17,13 +17,19 @@ export interface ProcessInfo {
  * Output format: p<pid>\nfcwd\nn<path> per process — `f` lines are
  * intentionally skipped since we only need `p` (PID) and `n` (path).
  */
-export async function getBatchWorkingDirectories(pids: number[]): Promise<Map<number, string>> {
+export async function getBatchWorkingDirectories(
+  pids: number[],
+): Promise<Map<number, string>> {
   const result = new Map<number, string>();
   if (pids.length === 0) return result;
   try {
-    const { stdout } = await execFileAsync("lsof", ["-p", pids.join(","), "-Fpn", "-d", "cwd"], {
-      timeout: PROCESS_TIMEOUT_MS,
-    });
+    const { stdout } = await execFileAsync(
+      "lsof",
+      ["-p", pids.join(","), "-Fpn", "-d", "cwd"],
+      {
+        timeout: PROCESS_TIMEOUT_MS,
+      },
+    );
     let currentPid: number | null = null;
     for (const line of stdout.split("\n")) {
       if (line.startsWith("p")) {
@@ -45,9 +51,13 @@ export async function getBatchWorkingDirectories(pids: number[]): Promise<Map<nu
  */
 export async function isClaudeProcess(pid: number): Promise<boolean> {
   try {
-    const { stdout } = await execFileAsync("ps", ["-o", "comm=", "-p", String(pid)], {
-      timeout: PROCESS_TIMEOUT_MS,
-    });
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-o", "comm=", "-p", String(pid)],
+      {
+        timeout: PROCESS_TIMEOUT_MS,
+      },
+    );
     const comm = stdout.trim();
     const basename = comm.includes("/") ? comm.split("/").pop() || comm : comm;
     return basename === "claude";

--- a/src/lib/shell-env.ts
+++ b/src/lib/shell-env.ts
@@ -18,13 +18,9 @@ let resolved: NodeJS.ProcessEnv | undefined;
 export async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
   if (resolved) return resolved;
   try {
-    const { stdout } = await execFileAsync(
-      "/bin/sh",
-      ["-lc", "printenv PATH"],
-      {
-        timeout: 5000,
-      },
-    );
+    const { stdout } = await execFileAsync("/bin/sh", ["-lc", "printenv PATH"], {
+      timeout: 5000,
+    });
     const shellPath = stdout.trim();
     resolved = { ...process.env, PATH: shellPath };
   } catch {

--- a/src/lib/shell-env.ts
+++ b/src/lib/shell-env.ts
@@ -1,0 +1,38 @@
+import { execFile } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Resolve the user's login shell PATH. macOS GUI apps (DMG builds) inherit a
+ * minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) which doesn't include
+ * user-installed CLI tools. We source the login shell once to pick up the
+ * full PATH so spawned processes can find things like `claude`, `gh`, `cmux`, etc.
+ *
+ * The result is cached for the lifetime of the process.
+ */
+let resolved: NodeJS.ProcessEnv | undefined;
+
+export async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
+  if (resolved) return resolved;
+  try {
+    const { stdout } = await execFileAsync("/bin/sh", ["-lc", "printenv PATH"], {
+      timeout: 5000,
+    });
+    const shellPath = stdout.trim();
+    resolved = { ...process.env, PATH: shellPath };
+  } catch {
+    // Fallback: augment current PATH with common install locations
+    const home = homedir();
+    const extra = [
+      join(home, ".local", "bin"),
+      join(home, ".claude", "bin"),
+      "/usr/local/bin",
+      "/opt/homebrew/bin",
+    ].join(":");
+    resolved = { ...process.env, PATH: `${extra}:${process.env.PATH ?? ""}` };
+  }
+  return resolved;
+}

--- a/src/lib/shell-env.ts
+++ b/src/lib/shell-env.ts
@@ -18,9 +18,13 @@ let resolved: NodeJS.ProcessEnv | undefined;
 export async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
   if (resolved) return resolved;
   try {
-    const { stdout } = await execFileAsync("/bin/sh", ["-lc", "printenv PATH"], {
-      timeout: 5000,
-    });
+    const { stdout } = await execFileAsync(
+      "/bin/sh",
+      ["-lc", "printenv PATH"],
+      {
+        timeout: 5000,
+      },
+    );
     const shellPath = stdout.trim();
     resolved = { ...process.env, PATH: shellPath };
   } catch {

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -11,16 +11,7 @@ describe("adapter registry", () => {
 
   it("returns an adapter for every known terminal", async () => {
     const { getAdapter } = await import("./adapters/registry");
-    const knownApps: TerminalApp[] = [
-      "iterm",
-      "terminal-app",
-      "ghostty",
-      "kitty",
-      "wezterm",
-      "alacritty",
-      "warp",
-      "cmux",
-    ];
+    const knownApps: TerminalApp[] = ["iterm", "terminal-app", "ghostty", "kitty", "wezterm", "alacritty", "warp", "cmux"];
 
     for (const app of knownApps) {
       const adapter = getAdapter(app);
@@ -155,10 +146,7 @@ describe("kitty adapter", () => {
   /** Create an exec mock that returns fakeLsOutput for `kitten @ ls` */
   function mockExecWithLs() {
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (
-        err: null,
-        result: { stdout: string; stderr: string },
-      ) => void;
+      const cb = args[args.length - 1] as (err: null, result: { stdout: string; stderr: string }) => void;
       const cmdArgs = args[1] as string[];
       // Return ls output when kitten @ ... ls is called
       if (args[0] === "kitten" && cmdArgs.includes("ls")) {
@@ -191,12 +179,7 @@ describe("kitty adapter", () => {
       expect.any(Function),
     );
     // Should also raise the macOS window
-    expect(execMock).toHaveBeenCalledWith(
-      "open",
-      ["-a", "kitty"],
-      expect.any(Object),
-      expect.any(Function),
-    );
+    expect(execMock).toHaveBeenCalledWith("open", ["-a", "kitty"], expect.any(Object), expect.any(Function));
   });
 
   it("sendText sends to resolved window id", async () => {
@@ -240,10 +223,7 @@ describe("kitty adapter", () => {
 
   it("focus still raises macOS window when kitten fails", async () => {
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (
-        err: Error | null,
-        result?: { stdout: string; stderr: string },
-      ) => void;
+      const cb = args[args.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void;
       if (args[0] === "kitten") {
         cb(new Error("remote control is not enabled"));
       } else {
@@ -255,20 +235,12 @@ describe("kitty adapter", () => {
     const { kittyAdapter } = await import("./adapters/kitty");
     await kittyAdapter.focus(kittyInfo);
 
-    expect(execMock).toHaveBeenCalledWith(
-      "open",
-      ["-a", "kitty"],
-      expect.any(Object),
-      expect.any(Function),
-    );
+    expect(execMock).toHaveBeenCalledWith("open", ["-a", "kitty"], expect.any(Object), expect.any(Function));
   });
 
   it("sendKeystroke falls back to generic when kitten fails", async () => {
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (
-        err: Error | null,
-        result?: { stdout: string; stderr: string },
-      ) => void;
+      const cb = args[args.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void;
       if (args[0] === "kitten") {
         cb(new Error("remote control is not enabled"));
       } else {
@@ -281,12 +253,7 @@ describe("kitty adapter", () => {
     await kittyAdapter.sendKeystroke(kittyInfo, "y");
 
     // Should fall back to System Events via generic adapter
-    expect(execMock).toHaveBeenCalledWith(
-      "osascript",
-      expect.any(Array),
-      expect.any(Object),
-      expect.any(Function),
-    );
+    expect(execMock).toHaveBeenCalledWith("osascript", expect.any(Array), expect.any(Object), expect.any(Function));
   });
 
   it("createSession uses kitten @ launch with tab type", async () => {
@@ -300,14 +267,7 @@ describe("kitty adapter", () => {
 
     expect(execMock).toHaveBeenCalledWith(
       "kitten",
-      expect.arrayContaining([
-        "launch",
-        "--type=tab",
-        "--cwd=/tmp",
-        "sh",
-        "-c",
-        "cd '/tmp' && claude",
-      ]),
+      expect.arrayContaining(["launch", "--type=tab", "--cwd=/tmp", "sh", "-c", "cd '/tmp' && claude"]),
       expect.any(Object),
       expect.any(Function),
     );
@@ -337,19 +297,14 @@ describe("kitty adapter", () => {
       {
         tabs: [
           {
-            windows: [
-              { id: 5, pid: 20045, foreground_processes: [{ pid: 24825 }] },
-            ],
+            windows: [{ id: 5, pid: 20045, foreground_processes: [{ pid: 24825 }] }],
           },
         ],
       },
     ]);
 
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (
-        err: null,
-        result: { stdout: string; stderr: string },
-      ) => void;
+      const cb = args[args.length - 1] as (err: null, result: { stdout: string; stderr: string }) => void;
       const cmdArgs = args[1] as string[];
       if (args[0] === "kitten" && cmdArgs.includes("ls")) {
         cb(null, { stdout: tmuxLsOutput, stderr: "" });
@@ -370,12 +325,7 @@ describe("kitty adapter", () => {
       expect.any(Function),
     );
     // Should also raise the macOS window
-    expect(execMock).toHaveBeenCalledWith(
-      "open",
-      ["-a", "kitty"],
-      expect.any(Object),
-      expect.any(Function),
-    );
+    expect(execMock).toHaveBeenCalledWith("open", ["-a", "kitty"], expect.any(Object), expect.any(Function));
   });
 
   it("createSession uses os-window type for window mode", async () => {
@@ -389,14 +339,7 @@ describe("kitty adapter", () => {
 
     expect(execMock).toHaveBeenCalledWith(
       "kitten",
-      expect.arrayContaining([
-        "launch",
-        "--type=os-window",
-        "--cwd=/tmp",
-        "sh",
-        "-c",
-        "cd '/tmp' && claude",
-      ]),
+      expect.arrayContaining(["launch", "--type=os-window", "--cwd=/tmp", "sh", "-c", "cd '/tmp' && claude"]),
       expect.any(Object),
       expect.any(Function),
     );
@@ -414,10 +357,7 @@ describe("public API tmux handling", () => {
     const execMock = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
     vi.doMock("child_process", () => ({
       execFile: (...args: unknown[]) => {
-        const cb = args[args.length - 1] as (
-          err: null,
-          result: { stdout: string; stderr: string },
-        ) => void;
+        const cb = args[args.length - 1] as (err: null, result: { stdout: string; stderr: string }) => void;
         execMock(...args);
         cb(null, { stdout: "", stderr: "" });
       },

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -11,7 +11,16 @@ describe("adapter registry", () => {
 
   it("returns an adapter for every known terminal", async () => {
     const { getAdapter } = await import("./adapters/registry");
-    const knownApps: TerminalApp[] = ["iterm", "terminal-app", "ghostty", "kitty", "wezterm", "alacritty", "warp", "cmux"];
+    const knownApps: TerminalApp[] = [
+      "iterm",
+      "terminal-app",
+      "ghostty",
+      "kitty",
+      "wezterm",
+      "alacritty",
+      "warp",
+      "cmux",
+    ];
 
     for (const app of knownApps) {
       const adapter = getAdapter(app);
@@ -146,7 +155,10 @@ describe("kitty adapter", () => {
   /** Create an exec mock that returns fakeLsOutput for `kitten @ ls` */
   function mockExecWithLs() {
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (err: null, result: { stdout: string; stderr: string }) => void;
+      const cb = args[args.length - 1] as (
+        err: null,
+        result: { stdout: string; stderr: string },
+      ) => void;
       const cmdArgs = args[1] as string[];
       // Return ls output when kitten @ ... ls is called
       if (args[0] === "kitten" && cmdArgs.includes("ls")) {
@@ -179,7 +191,12 @@ describe("kitty adapter", () => {
       expect.any(Function),
     );
     // Should also raise the macOS window
-    expect(execMock).toHaveBeenCalledWith("open", ["-a", "kitty"], expect.any(Object), expect.any(Function));
+    expect(execMock).toHaveBeenCalledWith(
+      "open",
+      ["-a", "kitty"],
+      expect.any(Object),
+      expect.any(Function),
+    );
   });
 
   it("sendText sends to resolved window id", async () => {
@@ -223,7 +240,10 @@ describe("kitty adapter", () => {
 
   it("focus still raises macOS window when kitten fails", async () => {
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+      const cb = args[args.length - 1] as (
+        err: Error | null,
+        result?: { stdout: string; stderr: string },
+      ) => void;
       if (args[0] === "kitten") {
         cb(new Error("remote control is not enabled"));
       } else {
@@ -235,12 +255,20 @@ describe("kitty adapter", () => {
     const { kittyAdapter } = await import("./adapters/kitty");
     await kittyAdapter.focus(kittyInfo);
 
-    expect(execMock).toHaveBeenCalledWith("open", ["-a", "kitty"], expect.any(Object), expect.any(Function));
+    expect(execMock).toHaveBeenCalledWith(
+      "open",
+      ["-a", "kitty"],
+      expect.any(Object),
+      expect.any(Function),
+    );
   });
 
   it("sendKeystroke falls back to generic when kitten fails", async () => {
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+      const cb = args[args.length - 1] as (
+        err: Error | null,
+        result?: { stdout: string; stderr: string },
+      ) => void;
       if (args[0] === "kitten") {
         cb(new Error("remote control is not enabled"));
       } else {
@@ -253,7 +281,12 @@ describe("kitty adapter", () => {
     await kittyAdapter.sendKeystroke(kittyInfo, "y");
 
     // Should fall back to System Events via generic adapter
-    expect(execMock).toHaveBeenCalledWith("osascript", expect.any(Array), expect.any(Object), expect.any(Function));
+    expect(execMock).toHaveBeenCalledWith(
+      "osascript",
+      expect.any(Array),
+      expect.any(Object),
+      expect.any(Function),
+    );
   });
 
   it("createSession uses kitten @ launch with tab type", async () => {
@@ -267,7 +300,14 @@ describe("kitty adapter", () => {
 
     expect(execMock).toHaveBeenCalledWith(
       "kitten",
-      expect.arrayContaining(["launch", "--type=tab", "--cwd=/tmp", "sh", "-c", "cd '/tmp' && claude"]),
+      expect.arrayContaining([
+        "launch",
+        "--type=tab",
+        "--cwd=/tmp",
+        "sh",
+        "-c",
+        "cd '/tmp' && claude",
+      ]),
       expect.any(Object),
       expect.any(Function),
     );
@@ -297,14 +337,19 @@ describe("kitty adapter", () => {
       {
         tabs: [
           {
-            windows: [{ id: 5, pid: 20045, foreground_processes: [{ pid: 24825 }] }],
+            windows: [
+              { id: 5, pid: 20045, foreground_processes: [{ pid: 24825 }] },
+            ],
           },
         ],
       },
     ]);
 
     const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
-      const cb = args[args.length - 1] as (err: null, result: { stdout: string; stderr: string }) => void;
+      const cb = args[args.length - 1] as (
+        err: null,
+        result: { stdout: string; stderr: string },
+      ) => void;
       const cmdArgs = args[1] as string[];
       if (args[0] === "kitten" && cmdArgs.includes("ls")) {
         cb(null, { stdout: tmuxLsOutput, stderr: "" });
@@ -325,7 +370,12 @@ describe("kitty adapter", () => {
       expect.any(Function),
     );
     // Should also raise the macOS window
-    expect(execMock).toHaveBeenCalledWith("open", ["-a", "kitty"], expect.any(Object), expect.any(Function));
+    expect(execMock).toHaveBeenCalledWith(
+      "open",
+      ["-a", "kitty"],
+      expect.any(Object),
+      expect.any(Function),
+    );
   });
 
   it("createSession uses os-window type for window mode", async () => {
@@ -339,7 +389,14 @@ describe("kitty adapter", () => {
 
     expect(execMock).toHaveBeenCalledWith(
       "kitten",
-      expect.arrayContaining(["launch", "--type=os-window", "--cwd=/tmp", "sh", "-c", "cd '/tmp' && claude"]),
+      expect.arrayContaining([
+        "launch",
+        "--type=os-window",
+        "--cwd=/tmp",
+        "sh",
+        "-c",
+        "cd '/tmp' && claude",
+      ]),
       expect.any(Object),
       expect.any(Function),
     );
@@ -357,7 +414,10 @@ describe("public API tmux handling", () => {
     const execMock = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
     vi.doMock("child_process", () => ({
       execFile: (...args: unknown[]) => {
-        const cb = args[args.length - 1] as (err: null, result: { stdout: string; stderr: string }) => void;
+        const cb = args[args.length - 1] as (
+          err: null,
+          result: { stdout: string; stderr: string },
+        ) => void;
         execMock(...args);
         cb(null, { stdout: "", stderr: "" });
       },

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -11,7 +11,7 @@ describe("adapter registry", () => {
 
   it("returns an adapter for every known terminal", async () => {
     const { getAdapter } = await import("./adapters/registry");
-    const knownApps: TerminalApp[] = ["iterm", "terminal-app", "ghostty", "kitty", "wezterm", "alacritty", "warp"];
+    const knownApps: TerminalApp[] = ["iterm", "terminal-app", "ghostty", "kitty", "wezterm", "alacritty", "warp", "cmux"];
 
     for (const app of knownApps) {
       const adapter = getAdapter(app);

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -11,7 +11,16 @@ describe("adapter registry", () => {
 
   it("returns an adapter for every known terminal", async () => {
     const { getAdapter } = await import("./adapters/registry");
-    const knownApps: TerminalApp[] = ["iterm", "terminal-app", "ghostty", "kitty", "wezterm", "alacritty", "warp", "cmux"];
+    const knownApps: TerminalApp[] = [
+      "iterm",
+      "terminal-app",
+      "ghostty",
+      "kitty",
+      "wezterm",
+      "alacritty",
+      "warp",
+      "cmux",
+    ];
 
     for (const app of knownApps) {
       const adapter = getAdapter(app);

--- a/src/lib/terminal/adapters/cmux.ts
+++ b/src/lib/terminal/adapters/cmux.ts
@@ -1,0 +1,137 @@
+import { readFile } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+import type { TerminalInfo } from "../types";
+import {
+  escapeForAppleScript,
+  execFileAsync,
+  mapKeystrokeToSystemEvents,
+  OSASCRIPT_TIMEOUT_MS,
+  systemEventsScript,
+} from "./shared";
+import type { CreateSessionOpts, TerminalAdapter } from "./types";
+
+const SESSION_PATH = join(
+  homedir(),
+  "Library",
+  "Application Support",
+  "cmux",
+  "session-com.cmuxterm.app.json",
+);
+
+/**
+ * Find the cmux terminal panel ID for a given TTY by reading cmux's session file.
+ * The session JSON contains each panel's `ttyName` and `id` (UUID), which lets us
+ * target the exact terminal via cmux's native AppleScript commands.
+ */
+async function findTerminalIdByTty(tty: string): Promise<string | null> {
+  try {
+    const raw = await readFile(SESSION_PATH, "utf-8");
+    const session = JSON.parse(raw);
+    const normalizedTty = tty.replace(/^\/dev\//, "");
+
+    for (const window of session.windows ?? []) {
+      for (const workspace of window.tabManager?.workspaces ?? []) {
+        for (const panel of workspace.panels ?? []) {
+          if (panel.ttyName === normalizedTty) {
+            return panel.id;
+          }
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build an AppleScript snippet that finds a terminal by ID, selects its
+ * containing workspace (tab), and then runs an action on the terminal.
+ * This mirrors iTerm's pattern of iterating sessions to find a TTY match.
+ */
+function scriptForTerminal(terminalId: string, action: string): string {
+  const safeId = escapeForAppleScript(terminalId);
+  return `tell application "cmux"
+  set targetId to "${safeId}"
+  repeat with w in every window
+    repeat with tb in every tab of w
+      repeat with t in every terminal of tb
+        if id of t is targetId then
+          select tab tb
+          delay 0.15
+          ${action}
+          return
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell`;
+}
+
+export const cmuxAdapter: TerminalAdapter = {
+  async focus(info: TerminalInfo): Promise<void> {
+    const terminalId = await findTerminalIdByTty(info.tty);
+    if (terminalId) {
+      const script = scriptForTerminal(terminalId, "focus t");
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+    } else {
+      await execFileAsync("osascript", ["-e", 'tell application "cmux" to activate'], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
+    }
+  },
+
+  async sendText(info: TerminalInfo, text: string): Promise<void> {
+    const terminalId = await findTerminalIdByTty(info.tty);
+    const asEscaped = escapeForAppleScript(text + "\n");
+    if (terminalId) {
+      const script = scriptForTerminal(terminalId, `input text "${asEscaped}" to t`);
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+    } else {
+      const action = systemEventsScript("cmux", `keystroke "${asEscaped}"`);
+      await execFileAsync("osascript", ["-e", action], { timeout: OSASCRIPT_TIMEOUT_MS });
+    }
+  },
+
+  async sendKeystroke(info: TerminalInfo, keystroke: string): Promise<void> {
+    const terminalId = await findTerminalIdByTty(info.tty);
+    const asKeystroke = mapKeystrokeToSystemEvents(keystroke);
+    if (terminalId) {
+      // Focus the correct terminal first, then send the keystroke via System Events
+      const script = scriptForTerminal(
+        terminalId,
+        `focus t
+        delay 0.1
+tell application "System Events"
+  tell process "cmux"
+    ${asKeystroke}
+  end tell
+end tell`,
+      );
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+    } else {
+      const script = `tell application "cmux" to activate
+tell application "System Events"
+  tell process "cmux"
+    ${asKeystroke}
+  end tell
+end tell`;
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+    }
+  },
+
+  async createSession(command: string, _opts: CreateSessionOpts): Promise<void> {
+    const asCmd = escapeForAppleScript(command + "\n");
+    const script = `tell application "cmux"
+  set newWs to new tab
+  select tab newWs
+  delay 0.15
+  set t to focused terminal of newWs
+  focus t
+  input text "${asCmd}" to t
+end tell`;
+    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+  },
+};

--- a/src/lib/terminal/adapters/cmux.ts
+++ b/src/lib/terminal/adapters/cmux.ts
@@ -75,11 +75,17 @@ export const cmuxAdapter: TerminalAdapter = {
     const terminalId = await findTerminalIdByTty(info.tty);
     if (terminalId) {
       const script = scriptForTerminal(terminalId, "focus t");
-      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
-    } else {
-      await execFileAsync("osascript", ["-e", 'tell application "cmux" to activate'], {
+      await execFileAsync("osascript", ["-e", script], {
         timeout: OSASCRIPT_TIMEOUT_MS,
       });
+    } else {
+      await execFileAsync(
+        "osascript",
+        ["-e", 'tell application "cmux" to activate'],
+        {
+          timeout: OSASCRIPT_TIMEOUT_MS,
+        },
+      );
     }
   },
 
@@ -87,11 +93,18 @@ export const cmuxAdapter: TerminalAdapter = {
     const terminalId = await findTerminalIdByTty(info.tty);
     const asEscaped = escapeForAppleScript(text + "\n");
     if (terminalId) {
-      const script = scriptForTerminal(terminalId, `input text "${asEscaped}" to t`);
-      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+      const script = scriptForTerminal(
+        terminalId,
+        `input text "${asEscaped}" to t`,
+      );
+      await execFileAsync("osascript", ["-e", script], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     } else {
       const action = systemEventsScript("cmux", `keystroke "${asEscaped}"`);
-      await execFileAsync("osascript", ["-e", action], { timeout: OSASCRIPT_TIMEOUT_MS });
+      await execFileAsync("osascript", ["-e", action], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     }
   },
 
@@ -110,7 +123,9 @@ tell application "System Events"
   end tell
 end tell`,
       );
-      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+      await execFileAsync("osascript", ["-e", script], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     } else {
       const script = `tell application "cmux" to activate
 tell application "System Events"
@@ -118,11 +133,16 @@ tell application "System Events"
     ${asKeystroke}
   end tell
 end tell`;
-      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+      await execFileAsync("osascript", ["-e", script], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     }
   },
 
-  async createSession(command: string, _opts: CreateSessionOpts): Promise<void> {
+  async createSession(
+    command: string,
+    _opts: CreateSessionOpts,
+  ): Promise<void> {
     const asCmd = escapeForAppleScript(command + "\n");
     const script = `tell application "cmux"
   set newWs to new tab
@@ -132,6 +152,8 @@ end tell`;
   focus t
   input text "${asCmd}" to t
 end tell`;
-    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+    await execFileAsync("osascript", ["-e", script], {
+      timeout: OSASCRIPT_TIMEOUT_MS,
+    });
   },
 };

--- a/src/lib/terminal/adapters/cmux.ts
+++ b/src/lib/terminal/adapters/cmux.ts
@@ -12,13 +12,7 @@ import {
 } from "./shared";
 import type { CreateSessionOpts, TerminalAdapter } from "./types";
 
-const SESSION_PATH = join(
-  homedir(),
-  "Library",
-  "Application Support",
-  "cmux",
-  "session-com.cmuxterm.app.json",
-);
+const SESSION_PATH = join(homedir(), "Library", "Application Support", "cmux", "session-com.cmuxterm.app.json");
 
 /**
  * Find the cmux terminal panel ID for a given TTY by reading cmux's session file.

--- a/src/lib/terminal/adapters/cmux.ts
+++ b/src/lib/terminal/adapters/cmux.ts
@@ -75,17 +75,11 @@ export const cmuxAdapter: TerminalAdapter = {
     const terminalId = await findTerminalIdByTty(info.tty);
     if (terminalId) {
       const script = scriptForTerminal(terminalId, "focus t");
-      await execFileAsync("osascript", ["-e", script], {
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+    } else {
+      await execFileAsync("osascript", ["-e", 'tell application "cmux" to activate'], {
         timeout: OSASCRIPT_TIMEOUT_MS,
       });
-    } else {
-      await execFileAsync(
-        "osascript",
-        ["-e", 'tell application "cmux" to activate'],
-        {
-          timeout: OSASCRIPT_TIMEOUT_MS,
-        },
-      );
     }
   },
 
@@ -93,18 +87,11 @@ export const cmuxAdapter: TerminalAdapter = {
     const terminalId = await findTerminalIdByTty(info.tty);
     const asEscaped = escapeForAppleScript(text + "\n");
     if (terminalId) {
-      const script = scriptForTerminal(
-        terminalId,
-        `input text "${asEscaped}" to t`,
-      );
-      await execFileAsync("osascript", ["-e", script], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      const script = scriptForTerminal(terminalId, `input text "${asEscaped}" to t`);
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
     } else {
       const action = systemEventsScript("cmux", `keystroke "${asEscaped}"`);
-      await execFileAsync("osascript", ["-e", action], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      await execFileAsync("osascript", ["-e", action], { timeout: OSASCRIPT_TIMEOUT_MS });
     }
   },
 
@@ -123,9 +110,7 @@ tell application "System Events"
   end tell
 end tell`,
       );
-      await execFileAsync("osascript", ["-e", script], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
     } else {
       const script = `tell application "cmux" to activate
 tell application "System Events"
@@ -133,16 +118,11 @@ tell application "System Events"
     ${asKeystroke}
   end tell
 end tell`;
-      await execFileAsync("osascript", ["-e", script], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
     }
   },
 
-  async createSession(
-    command: string,
-    _opts: CreateSessionOpts,
-  ): Promise<void> {
+  async createSession(command: string, _opts: CreateSessionOpts): Promise<void> {
     const asCmd = escapeForAppleScript(command + "\n");
     const script = `tell application "cmux"
   set newWs to new tab
@@ -152,8 +132,6 @@ end tell`;
   focus t
   input text "${asCmd}" to t
 end tell`;
-    await execFileAsync("osascript", ["-e", script], {
-      timeout: OSASCRIPT_TIMEOUT_MS,
-    });
+    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
   },
 };

--- a/src/lib/terminal/adapters/generic.ts
+++ b/src/lib/terminal/adapters/generic.ts
@@ -21,24 +21,44 @@ export function createGenericAdapter(
 ): TerminalAdapter {
   return {
     async focus(info: TerminalInfo): Promise<void> {
-      await execFileAsync("open", ["-a", info.appName], { timeout: OSASCRIPT_TIMEOUT_MS });
+      await execFileAsync("open", ["-a", info.appName], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     },
 
     async sendText(info: TerminalInfo, text: string): Promise<void> {
       const asEscaped = escapeForAppleScript(text);
-      const action = systemEventsScript(info.appName, `keystroke "${asEscaped}"\n    keystroke return`);
-      const script = withFocusDelay(genericActivateScript(info.appName), action, APPLESCRIPT_FOCUS_DELAY_S);
-      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+      const action = systemEventsScript(
+        info.appName,
+        `keystroke "${asEscaped}"\n    keystroke return`,
+      );
+      const script = withFocusDelay(
+        genericActivateScript(info.appName),
+        action,
+        APPLESCRIPT_FOCUS_DELAY_S,
+      );
+      await execFileAsync("osascript", ["-e", script], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     },
 
     async sendKeystroke(info: TerminalInfo, keystroke: string): Promise<void> {
       const asKeystroke = mapKeystrokeToSystemEvents(keystroke);
       const action = systemEventsScript(info.appName, asKeystroke);
-      const script = withFocusDelay(genericActivateScript(info.appName), action, APPLESCRIPT_FOCUS_DELAY_S);
-      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+      const script = withFocusDelay(
+        genericActivateScript(info.appName),
+        action,
+        APPLESCRIPT_FOCUS_DELAY_S,
+      );
+      await execFileAsync("osascript", ["-e", script], {
+        timeout: OSASCRIPT_TIMEOUT_MS,
+      });
     },
 
-    async createSession(command: string, _opts: CreateSessionOpts): Promise<void> {
+    async createSession(
+      command: string,
+      _opts: CreateSessionOpts,
+    ): Promise<void> {
       const { bin, args } = createArgs(command);
       const env = await getShellEnv();
       await execFileAsync(bin, args, { timeout: OSASCRIPT_TIMEOUT_MS, env });

--- a/src/lib/terminal/adapters/generic.ts
+++ b/src/lib/terminal/adapters/generic.ts
@@ -1,4 +1,5 @@
 import { APPLESCRIPT_FOCUS_DELAY_S } from "../../constants";
+import { getShellEnv } from "../../shell-env";
 import type { TerminalInfo } from "../types";
 import {
   escapeForAppleScript,
@@ -39,7 +40,8 @@ export function createGenericAdapter(
 
     async createSession(command: string, _opts: CreateSessionOpts): Promise<void> {
       const { bin, args } = createArgs(command);
-      await execFileAsync(bin, args, { timeout: OSASCRIPT_TIMEOUT_MS });
+      const env = await getShellEnv();
+      await execFileAsync(bin, args, { timeout: OSASCRIPT_TIMEOUT_MS, env });
     },
   };
 }

--- a/src/lib/terminal/adapters/generic.ts
+++ b/src/lib/terminal/adapters/generic.ts
@@ -21,44 +21,24 @@ export function createGenericAdapter(
 ): TerminalAdapter {
   return {
     async focus(info: TerminalInfo): Promise<void> {
-      await execFileAsync("open", ["-a", info.appName], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      await execFileAsync("open", ["-a", info.appName], { timeout: OSASCRIPT_TIMEOUT_MS });
     },
 
     async sendText(info: TerminalInfo, text: string): Promise<void> {
       const asEscaped = escapeForAppleScript(text);
-      const action = systemEventsScript(
-        info.appName,
-        `keystroke "${asEscaped}"\n    keystroke return`,
-      );
-      const script = withFocusDelay(
-        genericActivateScript(info.appName),
-        action,
-        APPLESCRIPT_FOCUS_DELAY_S,
-      );
-      await execFileAsync("osascript", ["-e", script], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      const action = systemEventsScript(info.appName, `keystroke "${asEscaped}"\n    keystroke return`);
+      const script = withFocusDelay(genericActivateScript(info.appName), action, APPLESCRIPT_FOCUS_DELAY_S);
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
     },
 
     async sendKeystroke(info: TerminalInfo, keystroke: string): Promise<void> {
       const asKeystroke = mapKeystrokeToSystemEvents(keystroke);
       const action = systemEventsScript(info.appName, asKeystroke);
-      const script = withFocusDelay(
-        genericActivateScript(info.appName),
-        action,
-        APPLESCRIPT_FOCUS_DELAY_S,
-      );
-      await execFileAsync("osascript", ["-e", script], {
-        timeout: OSASCRIPT_TIMEOUT_MS,
-      });
+      const script = withFocusDelay(genericActivateScript(info.appName), action, APPLESCRIPT_FOCUS_DELAY_S);
+      await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
     },
 
-    async createSession(
-      command: string,
-      _opts: CreateSessionOpts,
-    ): Promise<void> {
+    async createSession(command: string, _opts: CreateSessionOpts): Promise<void> {
       const { bin, args } = createArgs(command);
       const env = await getShellEnv();
       await execFileAsync(bin, args, { timeout: OSASCRIPT_TIMEOUT_MS, env });

--- a/src/lib/terminal/adapters/registry.ts
+++ b/src/lib/terminal/adapters/registry.ts
@@ -25,9 +25,6 @@ export function getAdapter(app: TerminalApp): TerminalAdapter | null {
 }
 
 /** Register a new terminal adapter at runtime. */
-export function registerAdapter(
-  app: TerminalApp,
-  adapter: TerminalAdapter,
-): void {
+export function registerAdapter(app: TerminalApp, adapter: TerminalAdapter): void {
   adapters[app] = adapter;
 }

--- a/src/lib/terminal/adapters/registry.ts
+++ b/src/lib/terminal/adapters/registry.ts
@@ -25,6 +25,9 @@ export function getAdapter(app: TerminalApp): TerminalAdapter | null {
 }
 
 /** Register a new terminal adapter at runtime. */
-export function registerAdapter(app: TerminalApp, adapter: TerminalAdapter): void {
+export function registerAdapter(
+  app: TerminalApp,
+  adapter: TerminalAdapter,
+): void {
   adapters[app] = adapter;
 }

--- a/src/lib/terminal/adapters/registry.ts
+++ b/src/lib/terminal/adapters/registry.ts
@@ -1,5 +1,6 @@
 import type { TerminalApp } from "../types";
 import { alacrittyAdapter } from "./alacritty";
+import { cmuxAdapter } from "./cmux";
 import { ghosttyAdapter } from "./ghostty";
 import { itermAdapter } from "./iterm";
 import { kittyAdapter } from "./kitty";
@@ -16,6 +17,7 @@ const adapters: Partial<Record<TerminalApp, TerminalAdapter>> = {
   wezterm: weztermAdapter,
   alacritty: alacrittyAdapter,
   warp: warpAdapter,
+  cmux: cmuxAdapter,
 };
 
 export function getAdapter(app: TerminalApp): TerminalAdapter | null {

--- a/src/lib/terminal/detect.test.ts
+++ b/src/lib/terminal/detect.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { findClaudePidsFromTree, findTerminalInTree, isOrphaned, matchTerminal } from "./detect";
+import {
+  findClaudePidsFromTree,
+  findTerminalInTree,
+  isOrphaned,
+  matchTerminal,
+} from "./detect";
 import type { ProcessTreeEntry } from "./types";
 
 describe("matchTerminal", () => {
@@ -12,7 +17,9 @@ describe("matchTerminal", () => {
   });
 
   it("matches from full macOS path", () => {
-    expect(matchTerminal("/Applications/iTerm.app/Contents/MacOS/iTerm2")).toEqual({
+    expect(
+      matchTerminal("/Applications/iTerm.app/Contents/MacOS/iTerm2"),
+    ).toEqual({
       app: "iterm",
       appName: "iTerm2",
       processName: "iTerm2",
@@ -103,7 +110,9 @@ describe("findTerminalInTree", () => {
   });
 
   it("handles cycle protection (pid points to itself)", () => {
-    const tree = new Map<number, ProcessTreeEntry>([[100, { ppid: 100, comm: "claude", cpuPercent: 0 }]]);
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 100, comm: "claude", cpuPercent: 0 }],
+    ]);
     const result = findTerminalInTree(100, tree);
     expect(result.app).toBe("unknown");
   });
@@ -117,7 +126,14 @@ describe("findTerminalInTree", () => {
     const tree = new Map<number, ProcessTreeEntry>([
       [100, { ppid: 50, comm: "claude", cpuPercent: 0 }],
       [50, { ppid: 10, comm: "/bin/zsh", cpuPercent: 0 }],
-      [10, { ppid: 1, comm: "/Applications/Ghostty.app/Contents/MacOS/ghostty", cpuPercent: 0 }],
+      [
+        10,
+        {
+          ppid: 1,
+          comm: "/Applications/Ghostty.app/Contents/MacOS/ghostty",
+          cpuPercent: 0,
+        },
+      ],
     ]);
     const result = findTerminalInTree(100, tree);
     expect(result.app).toBe("ghostty");
@@ -159,7 +175,10 @@ describe("findClaudePidsFromTree", () => {
 
   it("matches claude with full path (e.g. cmux terminals)", () => {
     const tree = new Map<number, ProcessTreeEntry>([
-      [100, { ppid: 50, comm: "/Users/someone/.local/bin/claude", cpuPercent: 0 }],
+      [
+        100,
+        { ppid: 50, comm: "/Users/someone/.local/bin/claude", cpuPercent: 0 },
+      ],
       [50, { ppid: 10, comm: "zsh", cpuPercent: 0 }],
     ]);
     const pids = findClaudePidsFromTree(tree);
@@ -168,7 +187,9 @@ describe("findClaudePidsFromTree", () => {
   });
 
   it("does not match partial names like claude-code", () => {
-    const tree = new Map<number, ProcessTreeEntry>([[100, { ppid: 50, comm: "claude-code", cpuPercent: 0 }]]);
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 50, comm: "claude-code", cpuPercent: 0 }],
+    ]);
     expect(findClaudePidsFromTree(tree)).toHaveLength(0);
   });
 });

--- a/src/lib/terminal/detect.test.ts
+++ b/src/lib/terminal/detect.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  findClaudePidsFromTree,
-  findTerminalInTree,
-  isOrphaned,
-  matchTerminal,
-} from "./detect";
+import { findClaudePidsFromTree, findTerminalInTree, isOrphaned, matchTerminal } from "./detect";
 import type { ProcessTreeEntry } from "./types";
 
 describe("matchTerminal", () => {
@@ -17,9 +12,7 @@ describe("matchTerminal", () => {
   });
 
   it("matches from full macOS path", () => {
-    expect(
-      matchTerminal("/Applications/iTerm.app/Contents/MacOS/iTerm2"),
-    ).toEqual({
+    expect(matchTerminal("/Applications/iTerm.app/Contents/MacOS/iTerm2")).toEqual({
       app: "iterm",
       appName: "iTerm2",
       processName: "iTerm2",
@@ -110,9 +103,7 @@ describe("findTerminalInTree", () => {
   });
 
   it("handles cycle protection (pid points to itself)", () => {
-    const tree = new Map<number, ProcessTreeEntry>([
-      [100, { ppid: 100, comm: "claude", cpuPercent: 0 }],
-    ]);
+    const tree = new Map<number, ProcessTreeEntry>([[100, { ppid: 100, comm: "claude", cpuPercent: 0 }]]);
     const result = findTerminalInTree(100, tree);
     expect(result.app).toBe("unknown");
   });
@@ -126,14 +117,7 @@ describe("findTerminalInTree", () => {
     const tree = new Map<number, ProcessTreeEntry>([
       [100, { ppid: 50, comm: "claude", cpuPercent: 0 }],
       [50, { ppid: 10, comm: "/bin/zsh", cpuPercent: 0 }],
-      [
-        10,
-        {
-          ppid: 1,
-          comm: "/Applications/Ghostty.app/Contents/MacOS/ghostty",
-          cpuPercent: 0,
-        },
-      ],
+      [10, { ppid: 1, comm: "/Applications/Ghostty.app/Contents/MacOS/ghostty", cpuPercent: 0 }],
     ]);
     const result = findTerminalInTree(100, tree);
     expect(result.app).toBe("ghostty");
@@ -175,10 +159,7 @@ describe("findClaudePidsFromTree", () => {
 
   it("matches claude with full path (e.g. cmux terminals)", () => {
     const tree = new Map<number, ProcessTreeEntry>([
-      [
-        100,
-        { ppid: 50, comm: "/Users/someone/.local/bin/claude", cpuPercent: 0 },
-      ],
+      [100, { ppid: 50, comm: "/Users/someone/.local/bin/claude", cpuPercent: 0 }],
       [50, { ppid: 10, comm: "zsh", cpuPercent: 0 }],
     ]);
     const pids = findClaudePidsFromTree(tree);
@@ -187,9 +168,7 @@ describe("findClaudePidsFromTree", () => {
   });
 
   it("does not match partial names like claude-code", () => {
-    const tree = new Map<number, ProcessTreeEntry>([
-      [100, { ppid: 50, comm: "claude-code", cpuPercent: 0 }],
-    ]);
+    const tree = new Map<number, ProcessTreeEntry>([[100, { ppid: 50, comm: "claude-code", cpuPercent: 0 }]]);
     expect(findClaudePidsFromTree(tree)).toHaveLength(0);
   });
 });

--- a/src/lib/terminal/detect.test.ts
+++ b/src/lib/terminal/detect.test.ts
@@ -51,6 +51,14 @@ describe("matchTerminal", () => {
     expect(matchTerminal("alacritty")?.app).toBe("alacritty");
   });
 
+  it("matches cmux", () => {
+    expect(matchTerminal("cmux")).toEqual({
+      app: "cmux",
+      appName: "Cmux",
+      processName: "cmux",
+    });
+  });
+
   it("returns null for unknown process", () => {
     expect(matchTerminal("sshd")).toBeNull();
   });
@@ -147,6 +155,16 @@ describe("findClaudePidsFromTree", () => {
       [10, { ppid: 1, comm: "iTerm2", cpuPercent: 0 }],
     ]);
     expect(findClaudePidsFromTree(tree)).toHaveLength(0);
+  });
+
+  it("matches claude with full path (e.g. cmux terminals)", () => {
+    const tree = new Map<number, ProcessTreeEntry>([
+      [100, { ppid: 50, comm: "/Users/someone/.local/bin/claude", cpuPercent: 0 }],
+      [50, { ppid: 10, comm: "zsh", cpuPercent: 0 }],
+    ]);
+    const pids = findClaudePidsFromTree(tree);
+    expect(pids).toContain(100);
+    expect(pids).toHaveLength(1);
   });
 
   it("does not match partial names like claude-code", () => {

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -1,28 +1,50 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { PROCESS_TIMEOUT_MS } from "../constants";
-import type { ProcessTreeEntry, TerminalApp, TerminalInfo, TmuxClientInfo, TmuxPaneInfo } from "./types";
+import type {
+  ProcessTreeEntry,
+  TerminalApp,
+  TerminalInfo,
+  TmuxClientInfo,
+  TmuxPaneInfo,
+} from "./types";
 
 const execFileAsync = promisify(execFile);
 
 // Known terminal mappings: process name (lowercased) → app info
-const KNOWN_TERMINALS: Record<string, { app: TerminalApp; appName: string; processName: string }> = {
+const KNOWN_TERMINALS: Record<
+  string,
+  { app: TerminalApp; appName: string; processName: string }
+> = {
   iterm2: { app: "iterm", appName: "iTerm2", processName: "iTerm2" },
-  terminal: { app: "terminal-app", appName: "Terminal", processName: "Terminal" },
+  terminal: {
+    app: "terminal-app",
+    appName: "Terminal",
+    processName: "Terminal",
+  },
   ghostty: { app: "ghostty", appName: "Ghostty", processName: "ghostty" },
   kitty: { app: "kitty", appName: "kitty", processName: "kitty" },
-  "wezterm-gui": { app: "wezterm", appName: "WezTerm", processName: "wezterm-gui" },
+  "wezterm-gui": {
+    app: "wezterm",
+    appName: "WezTerm",
+    processName: "wezterm-gui",
+  },
   wezterm: { app: "wezterm", appName: "WezTerm", processName: "WezTerm" },
-  alacritty: { app: "alacritty", appName: "Alacritty", processName: "alacritty" },
+  alacritty: {
+    app: "alacritty",
+    appName: "Alacritty",
+    processName: "alacritty",
+  },
   warp: { app: "warp", appName: "Warp", processName: "Warp" },
   cmux: { app: "cmux", appName: "Cmux", processName: "cmux" },
 };
 
-const UNKNOWN_TERMINAL: Pick<TerminalInfo, "app" | "appName" | "processName"> = {
-  app: "unknown",
-  appName: "Unknown",
-  processName: "unknown",
-};
+const UNKNOWN_TERMINAL: Pick<TerminalInfo, "app" | "appName" | "processName"> =
+  {
+    app: "unknown",
+    appName: "Unknown",
+    processName: "unknown",
+  };
 
 // Cache keyed by PID — only caches successful (non-unknown) detections
 const terminalCache = new Map<number, TerminalInfo>();
@@ -38,11 +60,17 @@ export function evictStaleTerminalCache(alivePids: Set<number>): void {
  * Returns a Map keyed by PID. Includes CPU% so discovery can skip
  * a second ps call for per-process details.
  */
-export async function buildProcessTree(): Promise<Map<number, ProcessTreeEntry>> {
+export async function buildProcessTree(): Promise<
+  Map<number, ProcessTreeEntry>
+> {
   try {
-    const { stdout } = await execFileAsync("ps", ["-eo", "pid,ppid,%cpu,comm"], {
-      timeout: PROCESS_TIMEOUT_MS,
-    });
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-eo", "pid,ppid,%cpu,comm"],
+      {
+        timeout: PROCESS_TIMEOUT_MS,
+      },
+    );
     const tree = new Map<number, ProcessTreeEntry>();
     for (const line of stdout.split("\n")) {
       const match = line.trim().match(/^(\d+)\s+(\d+)\s+([\d.,]+)\s+(.+)$/);
@@ -63,10 +91,14 @@ export async function buildProcessTree(): Promise<Map<number, ProcessTreeEntry>>
 /**
  * Extract PIDs from the process tree where comm is exactly "claude".
  */
-export function findClaudePidsFromTree(processTree: Map<number, ProcessTreeEntry>): number[] {
+export function findClaudePidsFromTree(
+  processTree: Map<number, ProcessTreeEntry>,
+): number[] {
   const pids: number[] = [];
   Array.from(processTree.entries()).forEach(([pid, entry]) => {
-    const basename = entry.comm.includes("/") ? entry.comm.split("/").pop() || entry.comm : entry.comm;
+    const basename = entry.comm.includes("/")
+      ? entry.comm.split("/").pop() || entry.comm
+      : entry.comm;
     if (basename === "claude") {
       pids.push(pid);
     }
@@ -78,13 +110,19 @@ export function findClaudePidsFromTree(processTree: Map<number, ProcessTreeEntry
  * Get TTYs for multiple PIDs in a single `ps` call.
  * Returns a Map of PID → normalized TTY path.
  */
-export async function getTtysForPids(pids: number[]): Promise<Map<number, string>> {
+export async function getTtysForPids(
+  pids: number[],
+): Promise<Map<number, string>> {
   const result = new Map<number, string>();
   if (pids.length === 0) return result;
   try {
-    const { stdout } = await execFileAsync("ps", ["-o", "pid=,tty=", "-p", pids.join(",")], {
-      timeout: PROCESS_TIMEOUT_MS,
-    });
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-o", "pid=,tty=", "-p", pids.join(",")],
+      {
+        timeout: PROCESS_TIMEOUT_MS,
+      },
+    );
     for (const line of stdout.trim().split("\n")) {
       const match = line.trim().match(/^(\d+)\s+(.+)$/);
       if (match) {
@@ -104,9 +142,13 @@ export async function getTtysForPids(pids: number[]): Promise<Map<number, string
  * Get the TTY for a single PID. Throws if no TTY found.
  */
 export async function getTtyForPid(pid: number): Promise<string> {
-  const { stdout } = await execFileAsync("ps", ["-o", "tty=", "-p", String(pid)], {
-    timeout: PROCESS_TIMEOUT_MS,
-  });
+  const { stdout } = await execFileAsync(
+    "ps",
+    ["-o", "tty=", "-p", String(pid)],
+    {
+      timeout: PROCESS_TIMEOUT_MS,
+    },
+  );
   const tty = stdout.trim();
   if (!tty || tty === "?" || tty === "??") {
     throw new Error(`No TTY found for PID ${pid}`);
@@ -125,7 +167,12 @@ export async function detectAllTmuxPanes(): Promise<Map<string, TmuxPaneInfo>> {
   try {
     const { stdout } = await execFileAsync(
       "tmux",
-      ["list-panes", "-a", "-F", "#{pane_tty}\t#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}"],
+      [
+        "list-panes",
+        "-a",
+        "-F",
+        "#{pane_tty}\t#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}",
+      ],
       { timeout: 5000 },
     );
     const panes = new Map<string, TmuxPaneInfo>();
@@ -167,7 +214,11 @@ export async function detectTmuxClients(): Promise<TmuxClientInfo[]> {
       if (parts.length < 3) continue;
       const pid = parseInt(parts[1], 10);
       if (!isNaN(pid)) {
-        clients.push({ tty: normalizeTty(parts[0]), pid, sessionName: parts[2] });
+        clients.push({
+          tty: normalizeTty(parts[0]),
+          pid,
+          sessionName: parts[2],
+        });
       }
     }
     return clients;
@@ -205,7 +256,9 @@ export function findTerminalInTree(
  * Match a process comm string against known terminals.
  * Handles full paths like /Applications/iTerm.app/Contents/MacOS/iTerm2.
  */
-export function matchTerminal(comm: string): Pick<TerminalInfo, "app" | "appName" | "processName"> | null {
+export function matchTerminal(
+  comm: string,
+): Pick<TerminalInfo, "app" | "appName" | "processName"> | null {
   const basename = comm.includes("/") ? comm.split("/").pop() || comm : comm;
   const lower = basename.toLowerCase();
 
@@ -223,7 +276,8 @@ export function matchTerminal(comm: string): Pick<TerminalInfo, "app" | "appName
   if (lowerComm.includes("iterm")) return KNOWN_TERMINALS["iterm2"];
   if (lowerComm.includes("ghostty")) return KNOWN_TERMINALS["ghostty"];
   if (lowerComm.includes("kitty")) return KNOWN_TERMINALS["kitty"];
-  if (lowerComm.includes("wezterm")) return KNOWN_TERMINALS["wezterm-gui"] ?? KNOWN_TERMINALS["wezterm"];
+  if (lowerComm.includes("wezterm"))
+    return KNOWN_TERMINALS["wezterm-gui"] ?? KNOWN_TERMINALS["wezterm"];
   if (lowerComm.includes("alacritty")) return KNOWN_TERMINALS["alacritty"];
   if (lowerComm.includes("warp")) return KNOWN_TERMINALS["warp"];
   if (lowerComm.includes("cmux")) return KNOWN_TERMINALS["cmux"];
@@ -255,7 +309,9 @@ export async function detectTerminal(
     if (inTmux && paneInfo) {
       // In tmux: trace from the tmux client PID to find the GUI terminal
       const clients = tmuxClients ?? (await detectTmuxClients());
-      const sessionClient = clients.find((c) => c.sessionName === paneInfo.sessionName);
+      const sessionClient = clients.find(
+        (c) => c.sessionName === paneInfo.sessionName,
+      );
 
       tmuxInfo = {
         paneId: paneInfo.paneId,
@@ -268,7 +324,9 @@ export async function detectTerminal(
       };
 
       termApp =
-        sessionClient && sessionClient.pid > 0 ? findTerminalInTree(sessionClient.pid, processTree) : UNKNOWN_TERMINAL;
+        sessionClient && sessionClient.pid > 0
+          ? findTerminalInTree(sessionClient.pid, processTree)
+          : UNKNOWN_TERMINAL;
     } else {
       // Not in tmux: walk up from the claude process itself
       termApp = findTerminalInTree(pid, processTree);
@@ -325,7 +383,9 @@ export function isOrphaned(
     visited.add(currentPid);
     const entry = processTree.get(currentPid);
     if (!entry) break;
-    const basename = entry.comm.includes("/") ? entry.comm.split("/").pop() || entry.comm : entry.comm;
+    const basename = entry.comm.includes("/")
+      ? entry.comm.split("/").pop() || entry.comm
+      : entry.comm;
     if (NON_ORPHAN_ANCESTORS.has(basename.toLowerCase())) return false;
     currentPid = entry.ppid;
   }

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -15,6 +15,7 @@ const KNOWN_TERMINALS: Record<string, { app: TerminalApp; appName: string; proce
   wezterm: { app: "wezterm", appName: "WezTerm", processName: "WezTerm" },
   alacritty: { app: "alacritty", appName: "Alacritty", processName: "alacritty" },
   warp: { app: "warp", appName: "Warp", processName: "Warp" },
+  cmux: { app: "cmux", appName: "Cmux", processName: "cmux" },
 };
 
 const UNKNOWN_TERMINAL: Pick<TerminalInfo, "app" | "appName" | "processName"> = {
@@ -65,7 +66,8 @@ export async function buildProcessTree(): Promise<Map<number, ProcessTreeEntry>>
 export function findClaudePidsFromTree(processTree: Map<number, ProcessTreeEntry>): number[] {
   const pids: number[] = [];
   Array.from(processTree.entries()).forEach(([pid, entry]) => {
-    if (entry.comm === "claude") {
+    const basename = entry.comm.includes("/") ? entry.comm.split("/").pop() || entry.comm : entry.comm;
+    if (basename === "claude") {
       pids.push(pid);
     }
   });
@@ -224,6 +226,7 @@ export function matchTerminal(comm: string): Pick<TerminalInfo, "app" | "appName
   if (lowerComm.includes("wezterm")) return KNOWN_TERMINALS["wezterm-gui"] ?? KNOWN_TERMINALS["wezterm"];
   if (lowerComm.includes("alacritty")) return KNOWN_TERMINALS["alacritty"];
   if (lowerComm.includes("warp")) return KNOWN_TERMINALS["warp"];
+  if (lowerComm.includes("cmux")) return KNOWN_TERMINALS["cmux"];
 
   return null;
 }

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -1,50 +1,28 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { PROCESS_TIMEOUT_MS } from "../constants";
-import type {
-  ProcessTreeEntry,
-  TerminalApp,
-  TerminalInfo,
-  TmuxClientInfo,
-  TmuxPaneInfo,
-} from "./types";
+import type { ProcessTreeEntry, TerminalApp, TerminalInfo, TmuxClientInfo, TmuxPaneInfo } from "./types";
 
 const execFileAsync = promisify(execFile);
 
 // Known terminal mappings: process name (lowercased) → app info
-const KNOWN_TERMINALS: Record<
-  string,
-  { app: TerminalApp; appName: string; processName: string }
-> = {
+const KNOWN_TERMINALS: Record<string, { app: TerminalApp; appName: string; processName: string }> = {
   iterm2: { app: "iterm", appName: "iTerm2", processName: "iTerm2" },
-  terminal: {
-    app: "terminal-app",
-    appName: "Terminal",
-    processName: "Terminal",
-  },
+  terminal: { app: "terminal-app", appName: "Terminal", processName: "Terminal" },
   ghostty: { app: "ghostty", appName: "Ghostty", processName: "ghostty" },
   kitty: { app: "kitty", appName: "kitty", processName: "kitty" },
-  "wezterm-gui": {
-    app: "wezterm",
-    appName: "WezTerm",
-    processName: "wezterm-gui",
-  },
+  "wezterm-gui": { app: "wezterm", appName: "WezTerm", processName: "wezterm-gui" },
   wezterm: { app: "wezterm", appName: "WezTerm", processName: "WezTerm" },
-  alacritty: {
-    app: "alacritty",
-    appName: "Alacritty",
-    processName: "alacritty",
-  },
+  alacritty: { app: "alacritty", appName: "Alacritty", processName: "alacritty" },
   warp: { app: "warp", appName: "Warp", processName: "Warp" },
   cmux: { app: "cmux", appName: "Cmux", processName: "cmux" },
 };
 
-const UNKNOWN_TERMINAL: Pick<TerminalInfo, "app" | "appName" | "processName"> =
-  {
-    app: "unknown",
-    appName: "Unknown",
-    processName: "unknown",
-  };
+const UNKNOWN_TERMINAL: Pick<TerminalInfo, "app" | "appName" | "processName"> = {
+  app: "unknown",
+  appName: "Unknown",
+  processName: "unknown",
+};
 
 // Cache keyed by PID — only caches successful (non-unknown) detections
 const terminalCache = new Map<number, TerminalInfo>();
@@ -60,17 +38,11 @@ export function evictStaleTerminalCache(alivePids: Set<number>): void {
  * Returns a Map keyed by PID. Includes CPU% so discovery can skip
  * a second ps call for per-process details.
  */
-export async function buildProcessTree(): Promise<
-  Map<number, ProcessTreeEntry>
-> {
+export async function buildProcessTree(): Promise<Map<number, ProcessTreeEntry>> {
   try {
-    const { stdout } = await execFileAsync(
-      "ps",
-      ["-eo", "pid,ppid,%cpu,comm"],
-      {
-        timeout: PROCESS_TIMEOUT_MS,
-      },
-    );
+    const { stdout } = await execFileAsync("ps", ["-eo", "pid,ppid,%cpu,comm"], {
+      timeout: PROCESS_TIMEOUT_MS,
+    });
     const tree = new Map<number, ProcessTreeEntry>();
     for (const line of stdout.split("\n")) {
       const match = line.trim().match(/^(\d+)\s+(\d+)\s+([\d.,]+)\s+(.+)$/);
@@ -91,14 +63,10 @@ export async function buildProcessTree(): Promise<
 /**
  * Extract PIDs from the process tree where comm is exactly "claude".
  */
-export function findClaudePidsFromTree(
-  processTree: Map<number, ProcessTreeEntry>,
-): number[] {
+export function findClaudePidsFromTree(processTree: Map<number, ProcessTreeEntry>): number[] {
   const pids: number[] = [];
   Array.from(processTree.entries()).forEach(([pid, entry]) => {
-    const basename = entry.comm.includes("/")
-      ? entry.comm.split("/").pop() || entry.comm
-      : entry.comm;
+    const basename = entry.comm.includes("/") ? entry.comm.split("/").pop() || entry.comm : entry.comm;
     if (basename === "claude") {
       pids.push(pid);
     }
@@ -110,19 +78,13 @@ export function findClaudePidsFromTree(
  * Get TTYs for multiple PIDs in a single `ps` call.
  * Returns a Map of PID → normalized TTY path.
  */
-export async function getTtysForPids(
-  pids: number[],
-): Promise<Map<number, string>> {
+export async function getTtysForPids(pids: number[]): Promise<Map<number, string>> {
   const result = new Map<number, string>();
   if (pids.length === 0) return result;
   try {
-    const { stdout } = await execFileAsync(
-      "ps",
-      ["-o", "pid=,tty=", "-p", pids.join(",")],
-      {
-        timeout: PROCESS_TIMEOUT_MS,
-      },
-    );
+    const { stdout } = await execFileAsync("ps", ["-o", "pid=,tty=", "-p", pids.join(",")], {
+      timeout: PROCESS_TIMEOUT_MS,
+    });
     for (const line of stdout.trim().split("\n")) {
       const match = line.trim().match(/^(\d+)\s+(.+)$/);
       if (match) {
@@ -142,13 +104,9 @@ export async function getTtysForPids(
  * Get the TTY for a single PID. Throws if no TTY found.
  */
 export async function getTtyForPid(pid: number): Promise<string> {
-  const { stdout } = await execFileAsync(
-    "ps",
-    ["-o", "tty=", "-p", String(pid)],
-    {
-      timeout: PROCESS_TIMEOUT_MS,
-    },
-  );
+  const { stdout } = await execFileAsync("ps", ["-o", "tty=", "-p", String(pid)], {
+    timeout: PROCESS_TIMEOUT_MS,
+  });
   const tty = stdout.trim();
   if (!tty || tty === "?" || tty === "??") {
     throw new Error(`No TTY found for PID ${pid}`);
@@ -167,12 +125,7 @@ export async function detectAllTmuxPanes(): Promise<Map<string, TmuxPaneInfo>> {
   try {
     const { stdout } = await execFileAsync(
       "tmux",
-      [
-        "list-panes",
-        "-a",
-        "-F",
-        "#{pane_tty}\t#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}",
-      ],
+      ["list-panes", "-a", "-F", "#{pane_tty}\t#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}"],
       { timeout: 5000 },
     );
     const panes = new Map<string, TmuxPaneInfo>();
@@ -214,11 +167,7 @@ export async function detectTmuxClients(): Promise<TmuxClientInfo[]> {
       if (parts.length < 3) continue;
       const pid = parseInt(parts[1], 10);
       if (!isNaN(pid)) {
-        clients.push({
-          tty: normalizeTty(parts[0]),
-          pid,
-          sessionName: parts[2],
-        });
+        clients.push({ tty: normalizeTty(parts[0]), pid, sessionName: parts[2] });
       }
     }
     return clients;
@@ -256,9 +205,7 @@ export function findTerminalInTree(
  * Match a process comm string against known terminals.
  * Handles full paths like /Applications/iTerm.app/Contents/MacOS/iTerm2.
  */
-export function matchTerminal(
-  comm: string,
-): Pick<TerminalInfo, "app" | "appName" | "processName"> | null {
+export function matchTerminal(comm: string): Pick<TerminalInfo, "app" | "appName" | "processName"> | null {
   const basename = comm.includes("/") ? comm.split("/").pop() || comm : comm;
   const lower = basename.toLowerCase();
 
@@ -276,8 +223,7 @@ export function matchTerminal(
   if (lowerComm.includes("iterm")) return KNOWN_TERMINALS["iterm2"];
   if (lowerComm.includes("ghostty")) return KNOWN_TERMINALS["ghostty"];
   if (lowerComm.includes("kitty")) return KNOWN_TERMINALS["kitty"];
-  if (lowerComm.includes("wezterm"))
-    return KNOWN_TERMINALS["wezterm-gui"] ?? KNOWN_TERMINALS["wezterm"];
+  if (lowerComm.includes("wezterm")) return KNOWN_TERMINALS["wezterm-gui"] ?? KNOWN_TERMINALS["wezterm"];
   if (lowerComm.includes("alacritty")) return KNOWN_TERMINALS["alacritty"];
   if (lowerComm.includes("warp")) return KNOWN_TERMINALS["warp"];
   if (lowerComm.includes("cmux")) return KNOWN_TERMINALS["cmux"];
@@ -309,9 +255,7 @@ export async function detectTerminal(
     if (inTmux && paneInfo) {
       // In tmux: trace from the tmux client PID to find the GUI terminal
       const clients = tmuxClients ?? (await detectTmuxClients());
-      const sessionClient = clients.find(
-        (c) => c.sessionName === paneInfo.sessionName,
-      );
+      const sessionClient = clients.find((c) => c.sessionName === paneInfo.sessionName);
 
       tmuxInfo = {
         paneId: paneInfo.paneId,
@@ -324,9 +268,7 @@ export async function detectTerminal(
       };
 
       termApp =
-        sessionClient && sessionClient.pid > 0
-          ? findTerminalInTree(sessionClient.pid, processTree)
-          : UNKNOWN_TERMINAL;
+        sessionClient && sessionClient.pid > 0 ? findTerminalInTree(sessionClient.pid, processTree) : UNKNOWN_TERMINAL;
     } else {
       // Not in tmux: walk up from the claude process itself
       termApp = findTerminalInTree(pid, processTree);
@@ -383,9 +325,7 @@ export function isOrphaned(
     visited.add(currentPid);
     const entry = processTree.get(currentPid);
     if (!entry) break;
-    const basename = entry.comm.includes("/")
-      ? entry.comm.split("/").pop() || entry.comm
-      : entry.comm;
+    const basename = entry.comm.includes("/") ? entry.comm.split("/").pop() || entry.comm : entry.comm;
     if (NON_ORPHAN_ANCESTORS.has(basename.toLowerCase())) return false;
     currentPid = entry.ppid;
   }

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -1,5 +1,14 @@
 // Terminal app identifiers — "iterm" (not "iterm2") matches process tree convention
-export type TerminalApp = "iterm" | "terminal-app" | "ghostty" | "kitty" | "wezterm" | "alacritty" | "warp" | "cmux" | "unknown";
+export type TerminalApp =
+  | "iterm"
+  | "terminal-app"
+  | "ghostty"
+  | "kitty"
+  | "wezterm"
+  | "alacritty"
+  | "warp"
+  | "cmux"
+  | "unknown";
 
 export type TerminalOpenIn = "tab" | "window";
 

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -1,5 +1,5 @@
 // Terminal app identifiers — "iterm" (not "iterm2") matches process tree convention
-export type TerminalApp = "iterm" | "terminal-app" | "ghostty" | "kitty" | "wezterm" | "alacritty" | "warp" | "unknown";
+export type TerminalApp = "iterm" | "terminal-app" | "ghostty" | "kitty" | "wezterm" | "alacritty" | "warp" | "cmux" | "unknown";
 
 export type TerminalOpenIn = "tab" | "window";
 

--- a/src/lib/terminal/types.ts
+++ b/src/lib/terminal/types.ts
@@ -1,14 +1,5 @@
 // Terminal app identifiers — "iterm" (not "iterm2") matches process tree convention
-export type TerminalApp =
-  | "iterm"
-  | "terminal-app"
-  | "ghostty"
-  | "kitty"
-  | "wezterm"
-  | "alacritty"
-  | "warp"
-  | "cmux"
-  | "unknown";
+export type TerminalApp = "iterm" | "terminal-app" | "ghostty" | "kitty" | "wezterm" | "alacritty" | "warp" | "cmux" | "unknown";
 
 export type TerminalOpenIn = "tab" | "window";
 


### PR DESCRIPTION
## Summary
- Add cmux as a fully supported terminal with native AppleScript adapter using cmux's scripting dictionary (`select tab`, `focus terminal`, `input text`) for reliable workspace and pane targeting across multiple windows
- Fix process detection to handle full-path `comm` values (e.g. `/Users/.../.local/bin/claude`) which some terminals report instead of bare `"claude"` — affects both session discovery and kill/cleanup
- Add shell-env utility to resolve login shell PATH in GUI/DMG builds so `which` checks and session creation can find CLI tools like `claude`, `gh`, `cmux`
- Improve worktree cleanup to handle already-deleted directories by inferring the main repo from the path

## Test plan
- [x] All 137 existing tests pass
- [x] New tests for cmux terminal matching and full-path claude PID detection
- [x] Manual: verify focus/sendText/sendKeystroke/createSession work in cmux with single and multiple windows
- [x] Manual: verify kill/cleanup works for cmux-hosted sessions
- [x] Manual: verify iTerm sessions still work as before