### PR TITLE
feat: version display, update check, and shell env fix

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,4 +1,7 @@
 import { execFile } from "child_process";
+import { access } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
 import { NextResponse } from "next/server";
 import { promisify } from "util";
 import {
@@ -53,7 +56,10 @@ interface DependencyDef {
   description: string;
   command: string;
   url: string;
+  knownPaths?: string[];
 }
+
+const home = homedir();
 
 const DEPENDENCIES: DependencyDef[] = [
   {
@@ -69,6 +75,12 @@ const DEPENDENCIES: DependencyDef[] = [
     description: "The whole reason this app exists",
     command: "claude",
     url: "https://docs.anthropic.com/en/docs/claude-code",
+    knownPaths: [
+      join(home, ".local", "bin", "claude"),
+      join(home, ".claude", "bin", "claude"),
+      "/usr/local/bin/claude",
+      "/opt/homebrew/bin/claude",
+    ],
   },
   {
     id: "tmux",
@@ -83,12 +95,25 @@ async function checkDependencies(): Promise<(DependencyDef & { installed: boolea
   const env = await getShellEnv();
   return Promise.all(
     DEPENDENCIES.map(async (dep) => {
+      // Try `which` first
       try {
         await execFileAsync("which", [dep.command], { timeout: 3000, env });
         return { ...dep, installed: true };
       } catch {
-        return { ...dep, installed: false };
+        // Fall through to known paths
       }
+      // Fallback: check known install locations directly
+      if (dep.knownPaths) {
+        for (const p of dep.knownPaths) {
+          try {
+            await access(p);
+            return { ...dep, installed: true };
+          } catch {
+            // Not at this path
+          }
+        }
+      }
+      return { ...dep, installed: false };
     }),
   );
 }

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import packageJson from "../../../../package.json";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_REPO = "sverrirsig/claude-control";
+
+interface GitHubRelease {
+  tag_name: string;
+  html_url: string;
+  assets: { name: string; browser_download_url: string }[];
+}
+
+export async function GET() {
+  const current = packageJson.version;
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`, {
+      headers: { Accept: "application/vnd.github.v3+json" },
+      next: { revalidate: 300 }, // cache for 5 minutes
+    });
+
+    if (!res.ok) {
+      return NextResponse.json({ current, latest: null, updateAvailable: false });
+    }
+
+    const release: GitHubRelease = await res.json();
+    const latest = release.tag_name.replace(/^v/, "");
+    const updateAvailable = latest !== current;
+
+    // Find the DMG asset for the current architecture
+    const dmgAsset = release.assets.find(
+      (a) => a.name.endsWith(".dmg") && (a.name.includes("arm64") || !a.name.includes("x64")),
+    );
+
+    return NextResponse.json({
+      current,
+      latest,
+      updateAvailable,
+      releaseUrl: release.html_url,
+      downloadUrl: dmgAsset?.browser_download_url ?? release.html_url,
+    });
+  } catch {
+    return NextResponse.json({ current, latest: null, updateAvailable: false });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,8 @@ export default function Dashboard() {
     return localStorage.getItem("showKeyboardHints") !== "false";
   });
   const [dismissToast, setDismissToast] = useState(false);
+  const [updateInfo, setUpdateInfo] = useState<{ latest: string; downloadUrl: string } | null>(null);
+  const [updateDismissed, setUpdateDismissed] = useState(false);
   // Optimistic approve/reject state: sessionId → { action, timestamp }
   const [actedSessions, setActedSessions] = useState<Record<string, { action: "approve" | "reject"; at: number }>>({});
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
@@ -78,6 +80,17 @@ export default function Dashboard() {
 
   const handleCancelEdit = useCallback(() => {
     setEditingSessionId(null);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/version")
+      .then((r) => r.json())
+      .then((v: { updateAvailable: boolean; latest: string; downloadUrl?: string }) => {
+        if (v.updateAvailable && v.downloadUrl) {
+          setUpdateInfo({ latest: v.latest, downloadUrl: v.downloadUrl });
+        }
+      })
+      .catch(() => {});
   }, []);
 
   const { selectedIndex, setSelectedIndex, selectedSession, actionFeedback } = useKeyboardShortcuts({
@@ -309,6 +322,36 @@ export default function Dashboard() {
             setTimeout(() => setDismissToast(false), 4000);
           }}
         />
+      )}
+
+      {updateInfo && !updateDismissed && (
+        <div className="fixed top-12 inset-x-0 z-40 pointer-events-none">
+          <div className="max-w-md mx-auto px-6">
+            <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-[#0a0a0f]/95 backdrop-blur-md border border-amber-500/20 pointer-events-auto shadow-lg shadow-black/30">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-zinc-200">
+                  Version <span className="font-medium text-amber-400">{updateInfo.latest}</span> is available
+                </p>
+              </div>
+              <a
+                href={updateInfo.downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium text-amber-300 hover:text-amber-200 bg-amber-500/10 hover:bg-amber-500/15 border border-amber-500/20 hover:border-amber-500/30 transition-colors"
+              >
+                Update
+              </a>
+              <button
+                onClick={() => setUpdateDismissed(true)}
+                className="shrink-0 text-zinc-600 hover:text-zinc-400 transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {dismissToast && (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,6 +4,14 @@ import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ScreenPicker } from "@/components/ScreenPicker";
 
+interface VersionInfo {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean;
+  releaseUrl?: string;
+  downloadUrl?: string;
+}
+
 interface OptionDef {
   id: string;
   label: string;
@@ -120,6 +128,7 @@ function SettingRow<T extends OptionDef>({
 
 export default function SettingsPage() {
   const [data, setData] = useState<SettingsData | null>(null);
+  const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const [saved, setSaved] = useState(false);
   const [addingDir, setAddingDir] = useState(false);
   const [targetScreen, setTargetScreen] = useState<number | null>(null);
@@ -147,6 +156,11 @@ export default function SettingsPage() {
         setPrPromptDraft(d.config.createPrPrompt ?? "");
         setBaseBranchDraft(d.config.defaultBaseBranch ?? "main");
       })
+      .catch(console.error);
+
+    fetch("/api/version")
+      .then((r) => r.json())
+      .then((v: VersionInfo) => setVersionInfo(v))
       .catch(console.error);
   }, []);
 
@@ -288,6 +302,45 @@ export default function SettingsPage() {
           </Link>
         </div>
       </div>
+
+      {/* Version section */}
+      {versionInfo && (
+        <section className="mb-10">
+          <div className="rounded-xl border border-white/6 bg-[#0a0a0f]/80 px-5 py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-zinc-500">Version</span>
+                <span className="text-sm font-medium text-zinc-200">{versionInfo.current}</span>
+                {versionInfo.updateAvailable && versionInfo.latest && (
+                  <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20">
+                    {versionInfo.latest} available
+                  </span>
+                )}
+                {versionInfo.latest && !versionInfo.updateAvailable && (
+                  <span className="text-xs text-zinc-600">up to date</span>
+                )}
+              </div>
+              {versionInfo.updateAvailable && versionInfo.downloadUrl && (
+                <a
+                  href={versionInfo.downloadUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-amber-300 hover:text-amber-200 bg-amber-500/10 hover:bg-amber-500/15 border border-amber-500/20 hover:border-amber-500/30 transition-colors"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                    />
+                  </svg>
+                  Download Update
+                </a>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Dependencies section */}
       <section className="mb-10">

--- a/src/lib/shell-env.ts
+++ b/src/lib/shell-env.ts
@@ -18,7 +18,11 @@ let resolved: NodeJS.ProcessEnv | undefined;
 export async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
   if (resolved) return resolved;
   try {
-    const { stdout } = await execFileAsync("/bin/sh", ["-lc", "printenv PATH"], {
+    // Use the user's actual login shell (zsh, bash, etc.) rather than /bin/sh,
+    // since /bin/sh -l only sources /etc/profile and ~/.profile, missing the
+    // PATH additions most users put in ~/.zshrc or ~/.bash_profile.
+    const shell = process.env.SHELL || "/bin/zsh";
+    const { stdout } = await execFileAsync(shell, ["-ilc", "printenv PATH"], {
       timeout: 5000,
     });
     const shellPath = stdout.trim();


### PR DESCRIPTION
## Summary
- Add version display to settings page showing the current version (read from package.json)
- Check the latest GitHub release and show an amber badge + "Download Update" button when a newer version is available
- Fix `getShellEnv` to use the user's actual login shell (`$SHELL` / `/bin/zsh`) instead of `/bin/sh`, which doesn't source `~/.zshrc` — this should fix the Claude Code dependency showing as not installed in DMG builds

## Test plan
- [ ] Manual: verify version shows "up to date" in settings when running latest
- [ ] Manual: verify Claude Code dependency shows green in DMG build
- [ ] Manual: verify "Download Update" button appears when running an older version