### PR TITLE
fix: resolve shell PATH at startup, fix false orphan detection

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,23 +1,74 @@
 const { app, BrowserWindow, shell, utilityProcess, dialog, ipcMain } = require("electron");
+const { execFileSync } = require("child_process");
 const { spawn } = require("child_process");
 const path = require("path");
 const net = require("net");
 const http = require("http");
+const os = require("os");
 
 const PORT = 3200;
 let nextProcess = null;
 
 // Electron apps launched from Finder/dock get a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin).
-// Augment it so child processes can find tools like `gh` installed via Homebrew or other managers.
-const EXTRA_PATHS = ["/opt/homebrew/bin", "/usr/local/bin", "/opt/homebrew/sbin"];
-if (process.env.PATH) {
-  const existing = process.env.PATH.split(":");
+// Resolve the user's real shell PATH once at startup so every child process inherits it.
+const EXTRA_PATHS = [
+  path.join(os.homedir(), ".local", "bin"),
+  path.join(os.homedir(), ".claude", "bin"),
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/opt/homebrew/sbin",
+];
+
+function getLoginShell() {
+  // process.env.SHELL can be stale (launchd caches it from login time).
+  // Query dscl for the authoritative value, fall back to $SHELL.
+  try {
+    const out = execFileSync("dscl", [".", "-read", `/Users/${os.userInfo().username}`, "UserShell"], {
+      timeout: 2000,
+      encoding: "utf-8",
+    });
+    const match = out.match(/UserShell:\s*(.+)/);
+    if (match) return match[1].trim();
+  } catch {
+    // dscl unavailable (Linux, etc.)
+  }
+  return process.env.SHELL || "/bin/zsh";
+}
+
+function resolveShellPath() {
+  const loginShell = getLoginShell();
+  // Try non-interactive login shell first (avoids TTY-dependent plugins),
+  // then interactive as fallback for users who set PATH only in .zshrc/.bashrc.
+  for (const flags of ["-lc", "-ilc"]) {
+    try {
+      const stdout = execFileSync(loginShell, [flags, "printenv PATH"], {
+        timeout: 3000,
+        encoding: "utf-8",
+        env: { ...process.env, TERM: "dumb", HOME: os.homedir() },
+      });
+      const shellPath = stdout.trim();
+      if (shellPath && shellPath.includes("/")) return shellPath;
+    } catch {
+      // Next attempt
+    }
+  }
+  return null;
+}
+
+const shellPath = resolveShellPath();
+if (shellPath) {
+  const parts = shellPath.split(":");
+  for (const p of EXTRA_PATHS) {
+    if (!parts.includes(p)) parts.push(p);
+  }
+  process.env.PATH = parts.join(":");
+} else {
+  // Fallback: merge extras into whatever PATH we have
+  const existing = (process.env.PATH || "/usr/bin:/bin:/usr/sbin:/sbin").split(":");
   for (const p of EXTRA_PATHS) {
     if (!existing.includes(p)) existing.push(p);
   }
   process.env.PATH = existing.join(":");
-} else {
-  process.env.PATH = ["/usr/bin", "/bin", "/usr/sbin", "/sbin", ...EXTRA_PATHS].join(":");
 }
 let mainWindow = null;
 let isQuitting = false;

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -68,6 +68,7 @@ const DEPENDENCIES: DependencyDef[] = [
     description: "Pull request detection and status checks",
     command: "gh",
     url: "https://cli.github.com",
+    knownPaths: ["/opt/homebrew/bin/gh", "/usr/local/bin/gh"],
   },
   {
     id: "claude",
@@ -88,6 +89,7 @@ const DEPENDENCIES: DependencyDef[] = [
     description: "Background terminal sessions and send-keys support",
     command: "tmux",
     url: "https://github.com/tmux/tmux",
+    knownPaths: ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux"],
   },
 ];
 

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -138,6 +138,11 @@ async function buildSession(
       hasPendingToolUse: pendingToolUse,
     });
 
+  // Recent user activity overrides orphan detection — if the session had
+  // input within the last 60s it's clearly not abandoned.
+  const recentActivity =
+    mtime !== null && Date.now() - mtime.getTime() < 60_000;
+
   return {
     id: sessionId,
     pid: info.pid,
@@ -155,7 +160,7 @@ async function buildSession(
     taskSummary,
     jsonlPath,
     prUrl,
-    orphaned,
+    orphaned: recentActivity ? false : orphaned,
     tmuxSession,
   };
 }

--- a/src/lib/shell-env.ts
+++ b/src/lib/shell-env.ts
@@ -1,42 +1,30 @@
-import { execFile } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
-import { promisify } from "util";
-
-const execFileAsync = promisify(execFile);
 
 /**
- * Resolve the user's login shell PATH. macOS GUI apps (DMG builds) inherit a
- * minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) which doesn't include
- * user-installed CLI tools. We source the login shell once to pick up the
- * full PATH so spawned processes can find things like `claude`, `gh`, `cmux`, etc.
- *
- * The result is cached for the lifetime of the process.
+ * Return process.env with common tool paths guaranteed present.
+ * The Electron main process resolves the user's login shell PATH at startup
+ * and sets process.env.PATH before spawning the server. This function exists
+ * as a safety net for dev mode or if the main-process resolution missed something.
  */
 let resolved: NodeJS.ProcessEnv | undefined;
 
 export async function getShellEnv(): Promise<NodeJS.ProcessEnv> {
   if (resolved) return resolved;
-  try {
-    // Use the user's actual login shell (zsh, bash, etc.) rather than /bin/sh,
-    // since /bin/sh -l only sources /etc/profile and ~/.profile, missing the
-    // PATH additions most users put in ~/.zshrc or ~/.bash_profile.
-    const shell = process.env.SHELL || "/bin/zsh";
-    const { stdout } = await execFileAsync(shell, ["-ilc", "printenv PATH"], {
-      timeout: 5000,
-    });
-    const shellPath = stdout.trim();
-    resolved = { ...process.env, PATH: shellPath };
-  } catch {
-    // Fallback: augment current PATH with common install locations
-    const home = homedir();
-    const extra = [
-      join(home, ".local", "bin"),
-      join(home, ".claude", "bin"),
-      "/usr/local/bin",
-      "/opt/homebrew/bin",
-    ].join(":");
-    resolved = { ...process.env, PATH: `${extra}:${process.env.PATH ?? ""}` };
+
+  const home = homedir();
+  const extraPaths = [
+    join(home, ".local", "bin"),
+    join(home, ".claude", "bin"),
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+  ];
+
+  const parts = (process.env.PATH || "").split(":");
+  for (const p of extraPaths) {
+    if (!parts.includes(p)) parts.push(p);
   }
+  resolved = { ...process.env, PATH: parts.join(":") };
   return resolved;
 }

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -397,7 +397,7 @@ describe("public API tmux handling", () => {
 
     // Should have called tmux send-keys, not the iTerm adapter
     expect(execMock).toHaveBeenCalledWith(
-      "tmux",
+      expect.stringContaining("tmux"),
       ["send-keys", "-t", "%5", "hello", "Enter"],
       expect.any(Object),
       expect.any(Function),

--- a/src/lib/terminal/adapters.ts
+++ b/src/lib/terminal/adapters.ts
@@ -4,6 +4,7 @@ import { PROCESS_TIMEOUT_MS } from "../constants";
 import { getAdapter } from "./adapters/registry";
 import { shellEscape, shellEscapeDouble } from "./adapters/shared";
 import { buildProcessTree, detectTmuxClients, findTerminalInTree } from "./detect";
+import { getTmuxBin } from "./tmux-bin";
 import type { TerminalApp, TerminalInfo } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -19,8 +20,8 @@ export async function focusSession(info: TerminalInfo): Promise<void> {
   // If in tmux, select the correct pane first
   if (info.inTmux && info.tmux) {
     const windowTarget = `${info.tmux.sessionName}:${info.tmux.windowIndex}`;
-    await execFileAsync("tmux", ["select-window", "-t", windowTarget], { timeout: PROCESS_TIMEOUT_MS });
-    await execFileAsync("tmux", ["select-pane", "-t", info.tmux.paneId], { timeout: PROCESS_TIMEOUT_MS });
+    await execFileAsync(getTmuxBin(), ["select-window", "-t", windowTarget], { timeout: PROCESS_TIMEOUT_MS });
+    await execFileAsync(getTmuxBin(), ["select-pane", "-t", info.tmux.paneId], { timeout: PROCESS_TIMEOUT_MS });
   }
 
   // Use tmux client TTY (terminal tab's TTY) when in tmux, otherwise the process's TTY
@@ -34,7 +35,7 @@ export async function focusSession(info: TerminalInfo): Promise<void> {
 export async function sendText(info: TerminalInfo, text: string): Promise<void> {
   // tmux: send directly to the pane — works in background without focus
   if (info.inTmux && info.tmux) {
-    await execFileAsync("tmux", ["send-keys", "-t", info.tmux.paneId, text, "Enter"], {
+    await execFileAsync(getTmuxBin(), ["send-keys", "-t", info.tmux.paneId, text, "Enter"], {
       timeout: PROCESS_TIMEOUT_MS,
     });
     return;
@@ -56,7 +57,7 @@ export async function sendKeystroke(info: TerminalInfo, keystroke: string): Prom
       tab: "Tab",
       space: "Space",
     };
-    await execFileAsync("tmux", ["send-keys", "-t", info.tmux.paneId, tmuxKeyMap[keystroke] ?? keystroke], {
+    await execFileAsync(getTmuxBin(), ["send-keys", "-t", info.tmux.paneId, tmuxKeyMap[keystroke] ?? keystroke], {
       timeout: PROCESS_TIMEOUT_MS,
     });
     return;
@@ -94,7 +95,7 @@ export async function createSession(opts: CreateSessionPublicOpts): Promise<void
   // Named tmux session: try adding a window to existing session
   if (useTmux && tmuxSession) {
     try {
-      await execFileAsync("tmux", ["new-window", "-t", tmuxSession, cmd], { timeout: 10000 });
+      await execFileAsync(getTmuxBin(), ["new-window", "-t", tmuxSession, cmd], { timeout: 10000 });
       // Focus the terminal tab that has the tmux client for this session
       try {
         const [clients, tree] = await Promise.all([detectTmuxClients(), buildProcessTree()]);
@@ -138,7 +139,7 @@ export async function createSession(opts: CreateSessionPublicOpts): Promise<void
 export async function listTmuxSessions(): Promise<{ name: string; windows: number; attached: boolean }[]> {
   try {
     const { stdout } = await execFileAsync(
-      "tmux",
+      getTmuxBin(),
       ["list-sessions", "-F", "#{session_name}\t#{session_windows}\t#{session_attached}"],
       { timeout: PROCESS_TIMEOUT_MS },
     );

--- a/src/lib/terminal/detect.ts
+++ b/src/lib/terminal/detect.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { PROCESS_TIMEOUT_MS } from "../constants";
+import { getTmuxBin } from "./tmux-bin";
 import type { ProcessTreeEntry, TerminalApp, TerminalInfo, TmuxClientInfo, TmuxPaneInfo } from "./types";
 
 const execFileAsync = promisify(execFile);
@@ -124,7 +125,7 @@ function normalizeTty(tty: string): string {
 export async function detectAllTmuxPanes(): Promise<Map<string, TmuxPaneInfo>> {
   try {
     const { stdout } = await execFileAsync(
-      "tmux",
+      getTmuxBin(),
       ["list-panes", "-a", "-F", "#{pane_tty}\t#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_index}"],
       { timeout: 5000 },
     );
@@ -157,7 +158,7 @@ export async function detectAllTmuxPanes(): Promise<Map<string, TmuxPaneInfo>> {
 export async function detectTmuxClients(): Promise<TmuxClientInfo[]> {
   try {
     const { stdout } = await execFileAsync(
-      "tmux",
+      getTmuxBin(),
       ["list-clients", "-F", "#{client_tty}\t#{client_pid}\t#{client_session}"],
       { timeout: 5000 },
     );

--- a/src/lib/terminal/tmux-bin.ts
+++ b/src/lib/terminal/tmux-bin.ts
@@ -1,0 +1,20 @@
+import { arch, platform } from "os";
+
+const HOMEBREW_TMUX = "/opt/homebrew/bin/tmux";
+
+let resolved: string | null = null;
+
+export function getTmuxBin(): string {
+  if (resolved !== null) return resolved;
+  if (platform() === "darwin" && arch() === "arm64") {
+    try {
+      require("fs").accessSync(HOMEBREW_TMUX);
+      resolved = HOMEBREW_TMUX;
+    } catch {
+      resolved = "tmux";
+    }
+  } else {
+    resolved = "tmux";
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary

Electron apps launched from Finder get a minimal PATH that often excludes `/opt/homebrew/bin`, causing `tmux` and `gh` to silently fail. Result: sessions show as `ORPHANED` despite having attached tmux clients, and Settings reports `gh`/`tmux` missing on Apple Silicon installs that have them via Homebrew.

## Changes

- Resolve the user's login shell PATH synchronously in `electron/main.js` at startup via `dscl` + shell invocation, so every child process (`utilityProcess`, spawned tmux/gh) inherits the correct PATH.
- Add `getTmuxBin()` helper that probes `/opt/homebrew/bin/tmux` before falling back to bare `tmux` on PATH.
- Add `knownPaths` fallback list for `gh` and `tmux` dependency checks in Settings.
- Suppress the orphan badge when a session has activity within the last 60s (avoids the brief flicker before tmux client list refreshes).
- Simplify `src/lib/shell-env.ts` to a safety-net — the real work happens once in `main.js`.

## Test plan

- [ ] Launch from Finder on Apple Silicon (Homebrew tmux/gh) — sessions with attached tmux clients show `WORKING`/`IDLE`, not `ORPHANED`.
- [ ] Settings → Dependencies shows `tmux` and `gh` as found.
- [ ] Launch from a terminal where PATH already contains `/opt/homebrew/bin` — no regression.
- [ ] Detach tmux client → session correctly transitions to `ORPHANED` after the 60s grace window.