### PR TITLE
build: shrink packaged app from 575MB to 296MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "typecheck": "tsc --noEmit",
     "electron:dev": "concurrently --kill-others \"next dev -p 3200\" \"wait-on http://localhost:3200 && electron .\"",
     "electron:build": "next build && node scripts/prepare-build.js && electron-builder --mac --publish never",
+    "electron:build:arm64": "next build && node scripts/prepare-build.js && electron-builder --mac --arm64 --publish never",
     "electron:pack": "next build && node scripts/prepare-build.js && electron-builder --mac --dir",
+    "electron:pack:arm64": "next build && node scripts/prepare-build.js && electron-builder --mac --arm64 --dir",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -74,7 +76,9 @@
       ]
     },
     "files": [
-      "electron/**/*"
+      "electron/**/*",
+      "!node_modules/@next/swc-*",
+      "!node_modules/@next/swc-*/**/*"
     ],
     "afterPack": "./scripts/after-pack.js"
   }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "dependencies": {
-    "next": "^16.2.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "swr": "^2.4.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@tailwindcss/postcss": "^4.2.2",
@@ -38,7 +33,11 @@
     "electron-builder": "^26.8.1",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.0",
+    "next": "^16.2.0",
     "postcss": "^8",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "swr": "^2.4.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^5",
     "vitest": "^4.1.0",

--- a/scripts/prepare-build.js
+++ b/scripts/prepare-build.js
@@ -18,6 +18,17 @@ console.log("Assembling standalone Next.js app...");
 // Use cp -RL to dereference symlinks and copy everything
 execSync(`cp -RL "${standaloneDir}" "${outDir}"`, { stdio: "inherit" });
 
+// Remove SWC native binaries — only needed at build time, not runtime
+const nextDir = path.join(outDir, "node_modules", "@next");
+if (fs.existsSync(nextDir)) {
+  for (const entry of fs.readdirSync(nextDir)) {
+    if (entry.startsWith("swc-")) {
+      fs.rmSync(path.join(nextDir, entry), { recursive: true });
+      console.log(`Removed @next/${entry} (build-time only).`);
+    }
+  }
+}
+
 // Copy static assets into .next/static
 const staticDest = path.join(outDir, ".next", "static");
 fs.mkdirSync(staticDest, { recursive: true });

--- a/scripts/prepare-build.js
+++ b/scripts/prepare-build.js
@@ -18,6 +18,22 @@ console.log("Assembling standalone Next.js app...");
 // Use cp -RL to dereference symlinks and copy everything
 execSync(`cp -RL "${standaloneDir}" "${outDir}"`, { stdio: "inherit" });
 
+// Next.js standalone copies the entire project root — strip everything the
+// runtime server doesn't need (build artifacts, source, configs, dist/).
+const KEEP_TOP_LEVEL = new Set([
+  "server.js",
+  "node_modules",
+  ".next",
+  "public",
+  "package.json",
+]);
+for (const entry of fs.readdirSync(outDir)) {
+  if (!KEEP_TOP_LEVEL.has(entry)) {
+    fs.rmSync(path.join(outDir, entry), { recursive: true });
+    console.log(`Removed ${entry} (not needed at runtime).`);
+  }
+}
+
 // Remove SWC native binaries — only needed at build time, not runtime
 const nextDir = path.join(outDir, "node_modules", "@next");
 if (fs.existsSync(nextDir)) {


### PR DESCRIPTION
## Summary

Two related changes that strip build-only artifacts from the packaged Electron app. Combined effect: **575MB → 296MB**.

1. **Exclude `@next/swc-*` native binaries** (`3a54cc6`)
   - The SWC compiler binaries (~116MB) are build-time only but were ending up in both the standalone `next-app` and the Electron asar.
   - Strip them in `scripts/prepare-build.js` and exclude from the asar via `electron-builder` `files` config.
   - Add `electron:build:arm64` and `electron:pack:arm64` scripts so Apple Silicon users can build natively without Rosetta.

2. **Move `next`/`react`/`react-dom`/`swr` to `devDependencies`** (`250d760`)
   - Electron main process doesn't import these — only the standalone Next server (which bundles its own `node_modules`) does.
   - Keeping them in `dependencies` made `electron-builder` pack a duplicate copy into the asar.
   - Also strip project-root files (`dist/`, `src/`, `docs/`) that the Next standalone output otherwise copies into `next-app-dist`.

## Test plan

- [ ] `npm run electron:pack` produces a working app on x64.
- [ ] `npm run electron:pack:arm64` produces a native arm64 build.
- [ ] Launching the packaged app loads the dashboard and starts/stops sessions normally.
- [ ] `du -sh dist/mac-arm64/Claude\ Control.app` reports ~296MB (down from ~575MB).