### PR TITLE
fix: restore merged PR badge and handle skipped checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,6 @@
       "name": "claude-control",
       "version": "0.15.0",
       "license": "MIT",
-      "dependencies": {
-        "next": "^16.2.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "swr": "^2.4.1"
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
         "@tailwindcss/postcss": "^4.2.2",
@@ -25,7 +19,11 @@
         "electron-builder": "^26.8.1",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.0",
+        "next": "^16.2.0",
         "postcss": "^8",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "swr": "^2.4.1",
         "tailwindcss": "^4.2.2",
         "typescript": "^5",
         "vitest": "^4.1.0",
@@ -931,6 +929,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1264,6 +1263,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1277,6 +1277,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1299,6 +1300,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1321,6 +1323,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1337,6 +1340,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1353,6 +1357,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1369,6 +1374,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1385,6 +1391,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1401,6 +1408,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1417,6 +1425,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1433,6 +1442,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1449,6 +1459,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1465,6 +1476,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1481,6 +1493,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1503,6 +1516,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1525,6 +1539,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1547,6 +1562,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1569,6 +1585,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1591,6 +1608,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1613,6 +1631,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1635,6 +1654,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1657,6 +1677,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1676,6 +1697,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1695,6 +1717,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1714,6 +1737,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1980,6 +2004,7 @@
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
       "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1999,6 +2024,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2015,6 +2041,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,6 +2058,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2047,6 +2075,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2063,6 +2092,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2079,6 +2109,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2095,6 +2126,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2111,6 +2143,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2553,6 +2586,7 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -4287,6 +4321,7 @@
       "version": "2.10.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
       "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4674,6 +4709,7 @@
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
       "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4811,6 +4847,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -5204,6 +5241,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5213,7 +5251,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8867,6 +8905,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8918,6 +8957,7 @@
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@next/env": "16.2.4",
@@ -8971,6 +9011,7 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9534,6 +9575,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -9770,6 +9812,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9779,6 +9822,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -10202,6 +10246,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -10292,6 +10337,7 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -10337,6 +10383,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -10569,6 +10616,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10873,6 +10921,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -10938,6 +10987,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
       "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -11250,6 +11300,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -11537,6 +11588,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/scripts/prepare-build.js
+++ b/scripts/prepare-build.js
@@ -20,13 +20,7 @@ execSync(`cp -RL "${standaloneDir}" "${outDir}"`, { stdio: "inherit" });
 
 // Next.js standalone copies the entire project root — strip everything the
 // runtime server doesn't need (build artifacts, source, configs, dist/).
-const KEEP_TOP_LEVEL = new Set([
-  "server.js",
-  "node_modules",
-  ".next",
-  "public",
-  "package.json",
-]);
+const KEEP_TOP_LEVEL = new Set(["server.js", "node_modules", ".next", "public", "package.json"]);
 for (const entry of fs.readdirSync(outDir)) {
   if (!KEEP_TOP_LEVEL.has(entry)) {
     fs.rmSync(path.join(outDir, entry), { recursive: true });

--- a/src/app/api/pr-status/route.ts
+++ b/src/app/api/pr-status/route.ts
@@ -74,12 +74,21 @@ async function fetchPrStatus(prUrl: string, cwd: string): Promise<PrStatus | nul
     let pending = 0;
 
     for (const check of rollup) {
-      if (check.conclusion === "SUCCESS" || check.state === "SUCCESS") {
+      // SKIPPED and NEUTRAL are terminal states — treat as done so the
+      // pending spinner doesn't hang when path filters skip half the matrix.
+      if (
+        check.conclusion === "SUCCESS" ||
+        check.conclusion === "SKIPPED" ||
+        check.conclusion === "NEUTRAL" ||
+        check.state === "SUCCESS"
+      ) {
         passing++;
       } else if (
         check.conclusion === "FAILURE" ||
         check.conclusion === "TIMED_OUT" ||
         check.conclusion === "CANCELLED" ||
+        check.conclusion === "ACTION_REQUIRED" ||
+        check.conclusion === "STARTUP_FAILURE" ||
         check.state === "FAILURE" ||
         check.state === "ERROR"
       ) {

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -140,8 +140,7 @@ async function buildSession(
 
   // Recent user activity overrides orphan detection — if the session had
   // input within the last 60s it's clearly not abandoned.
-  const recentActivity =
-    mtime !== null && Date.now() - mtime.getTime() < 60_000;
+  const recentActivity = mtime !== null && Date.now() - mtime.getTime() < 60_000;
 
   return {
     id: sessionId,

--- a/src/lib/git-info.ts
+++ b/src/lib/git-info.ts
@@ -76,9 +76,10 @@ export async function getPrUrl(cwd: string, branch: string): Promise<string | nu
   try {
     // Use `gh pr list --head` instead of `gh pr view` because the latter
     // interprets numeric branch names (e.g. "36") as PR numbers.
+    // `--state all` so merged/closed PRs still surface their status badge.
     const { stdout } = await execFileAsync(
       "gh",
-      ["pr", "list", "--head", branch, "--json", "url", "--jq", ".[0].url", "--state", "open", "--limit", "1"],
+      ["pr", "list", "--head", branch, "--json", "url", "--jq", ".[0].url", "--state", "all", "--limit", "1"],
       { cwd, timeout: 5000 },
     );
     const url = stdout.trim() || null;


### PR DESCRIPTION
## Summary

Two bug fixes plus the CI cleanup needed to land them:

- **Fix: merged PRs no longer show the "Merged" badge.** Commit `51df1f3` narrowed the PR URL lookup to `--state open` to dodge a numeric-branch issue. Side effect: once a PR merges, `getPrUrl` returns null, the session loses its `prUrl`, the dashboard never queries `/api/pr-status` for it, and the badge disappears. Switch back to `--state all` so merged/closed PRs still surface their status.
- **Fix: skipped checks left the spinner spinning forever.** The check categorizer in `pr-status/route.ts` only recognized `SUCCESS` and `FAILURE/TIMED_OUT/CANCELLED/ERROR` — everything else fell through to "pending." `SKIPPED` and `NEUTRAL` are terminal states, so the badge would show e.g. "5/10" with the spinner indefinitely on PRs where path filters skipped half the matrix. Classify both as passing; also add `ACTION_REQUIRED` and `STARTUP_FAILURE` to the failing branch.
- **Style: biome format on two files merged in #43 and #44** that were tripping `format:check` on main.
- **Chore: sync `package-lock.json` after the dependency reorg in #44** (the PR moved `next`/`react`/`react-dom`/`swr` between sections but didn't update the lockfile).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] In the running dev dashboard, recently-merged PRs show the purple "Merged" badge after the 30–60s cache TTL
- [ ] PRs with skipped checks show as passing (green) instead of pending (amber spinner)