### PR TITLE
feat: add Firefox Developer Edition browser option

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -56,6 +56,7 @@ export const BROWSER_OPTIONS = [
   { id: "chrome", label: "Google Chrome", appName: "Google Chrome" },
   { id: "arc", label: "Arc", appName: "Arc" },
   { id: "firefox", label: "Firefox", appName: "Firefox" },
+  { id: "firefox-dev", label: "Firefox Developer Edition", appName: "Firefox Developer Edition" },
   { id: "brave", label: "Brave", appName: "Brave Browser" },
   { id: "edge", label: "Microsoft Edge", appName: "Microsoft Edge" },
 ];


### PR DESCRIPTION
Closes #45.

## Summary

Adds Firefox Developer Edition as a separate option in the Settings → Browser picker. Reporter has only Dev Edition installed, so the existing "Firefox" entry showed as greyed-out "Firefox (not installed)" with no way to pick the Dev Edition.

Single-line addition to `BROWSER_OPTIONS`:

```ts
{ id: "firefox-dev", label: "Firefox Developer Edition", appName: "Firefox Developer Edition" },
```

Follows the existing pattern: one entry per app variant (Arc and Chrome are listed separately despite both being Chromium-based). Detection (`open -Ra "Firefox Developer Edition"`), the install-status badge, and the picker render automatically because they all iterate `BROWSER_OPTIONS`.

The URL launch path in `src/app/api/actions/open/route.ts` correctly falls through to the non-Chromium `open -a` branch — same path regular Firefox already uses — so no launch-side wiring is needed.

## Test plan

- [ ] Settings → Browser shows "Firefox Developer Edition" entry
- [ ] If installed, selectable (not greyed out)
- [ ] If not installed, shows "(not installed)" and is disabled
- [ ] Selecting it and triggering an open-url action launches Firefox Developer Edition

## CI note

The `style / format` job will fail until #46 merges — this is pre-existing biome format breakage on main from #43/#44 that #46 fixes, not from this change. Typecheck/lint/tests all pass on this branch.