### PR TITLE
Parse array-format user content in transcript previews

### DIFF
--- a/src/lib/session-reader.test.ts
+++ b/src/lib/session-reader.test.ts
@@ -30,6 +30,16 @@ function toolUseBlock(name: string, input?: Record<string, unknown>) {
   return { type: "tool_use", name, input };
 }
 
+// Current Claude Code (both terminal and the VS Code extension) writes user
+// turns as a content-block array rather than a plain string.
+function userArrayLine(blocks: Array<Record<string, unknown>>, extra = {}) {
+  return { type: "user", message: { role: "user", content: blocks }, ...extra };
+}
+
+function toolResultBlock(content: unknown = "result") {
+  return { type: "tool_result", tool_use_id: "toolu_x", content };
+}
+
 describe("extractSessionId", () => {
   it("finds first sessionId", () => {
     const lines = [
@@ -219,6 +229,48 @@ describe("extractPreview", () => {
     const lines = [assistantLine([toolUseBlock("Read", { file_path: "/etc/passwd" })])];
     expect(extractPreview(lines).lastTools[0].warnings).toEqual([]);
   });
+
+  it("extracts user text from array-format content", () => {
+    const lines = [userArrayLine([textBlock("fix the bug")]), assistantLine([textBlock("Done.")])];
+    const preview = extractPreview(lines);
+    expect(preview.lastUserMessage).toBe("fix the bug");
+    expect(preview.messageCount).toBe(2);
+  });
+
+  it("joins multiple text blocks in array-format user content", () => {
+    const lines = [userArrayLine([textBlock("first line"), textBlock("second line")])];
+    expect(extractPreview(lines).lastUserMessage).toBe("first line\nsecond line");
+  });
+
+  it("skips tool_result-only user array lines", () => {
+    const lines = [
+      userArrayLine([textBlock("run the tests")]),
+      assistantLine([toolUseBlock("Bash", { command: "npm test" })]),
+      userArrayLine([toolResultBlock("All passed")]),
+    ];
+    const preview = extractPreview(lines);
+    expect(preview.lastUserMessage).toBe("run the tests");
+    expect(preview.assistantIsNewer).toBe(true);
+  });
+
+  it("filters system-injected XML in array-format user content", () => {
+    const lines = [userArrayLine([textBlock("<system-reminder>Be helpful</system-reminder>")])];
+    const preview = extractPreview(lines);
+    expect(preview.lastUserMessage).toBeNull();
+    expect(preview.messageCount).toBe(0);
+  });
+
+  it("resets state on /clear in array-format user content", () => {
+    const lines = [
+      userArrayLine([textBlock("old message")]),
+      assistantLine([textBlock("old reply")]),
+      userArrayLine([textBlock("<command-name>/clear</command-name>")]),
+      userArrayLine([textBlock("new message")]),
+    ];
+    const preview = extractPreview(lines);
+    expect(preview.lastUserMessage).toBe("new message");
+    expect(preview.lastAssistantText).toBeNull();
+  });
 });
 
 describe("lastMessageHasError", () => {
@@ -400,6 +452,18 @@ describe("linesToConversation", () => {
     expect(msgs[0].text).toBe("hello");
     expect(msgs[1].text).toBe("Hi!");
   });
+
+  it("includes array-format user text and excludes tool_result-only lines", () => {
+    const lines = [
+      { ...userArrayLine([textBlock("hello there")]), timestamp: "t1" },
+      { ...assistantLine([toolUseBlock("Read", { file_path: "/x" })]), timestamp: "t2" },
+      { ...userArrayLine([toolResultBlock("file contents")]), timestamp: "t3" },
+    ];
+    const msgs = linesToConversation(lines);
+    const userMsgs = msgs.filter((m) => m.type === "user");
+    expect(userMsgs).toHaveLength(1);
+    expect(userMsgs[0].text).toBe("hello there");
+  });
 });
 
 describe("extractTaskSummary", () => {
@@ -464,6 +528,25 @@ describe("extractTaskSummary", () => {
     const lines = [
       userLine("<system-reminder>You are Claude Code</system-reminder>"),
       userLine("Build the auth module"),
+    ];
+    const summary = extractTaskSummary(lines);
+    expect(summary).not.toBeNull();
+    expect(summary!.title).toBe("Build the auth module");
+  });
+
+  it("falls back to first user message in array-format content", () => {
+    const lines = [userArrayLine([textBlock("Add dark mode toggle\nShould respect system preferences")])];
+    const summary = extractTaskSummary(lines);
+    expect(summary).not.toBeNull();
+    expect(summary!.title).toBe("Add dark mode toggle");
+    expect(summary!.description).toBe("Should respect system preferences");
+    expect(summary!.source).toBe("prompt");
+  });
+
+  it("skips tool_result-only array lines when finding task summary", () => {
+    const lines = [
+      userArrayLine([toolResultBlock("some tool output")]),
+      userArrayLine([textBlock("Build the auth module")]),
     ];
     const summary = extractTaskSummary(lines);
     expect(summary).not.toBeNull();

--- a/src/lib/session-reader.test.ts
+++ b/src/lib/session-reader.test.ts
@@ -32,7 +32,7 @@ function toolUseBlock(name: string, input?: Record<string, unknown>) {
 
 // Current Claude Code (both terminal and the VS Code extension) writes user
 // turns as a content-block array rather than a plain string.
-function userArrayLine(blocks: Array<Record<string, unknown>>, extra = {}) {
+function userArrayLine(blocks: ContentBlock[], extra = {}) {
   return { type: "user", message: { role: "user", content: blocks }, ...extra };
 }
 

--- a/src/lib/session-reader.ts
+++ b/src/lib/session-reader.ts
@@ -152,6 +152,25 @@ function stripXmlTags(text: string): string | null {
   return stripped.length > 0 ? stripped : null;
 }
 
+/**
+ * Extract human-authored text from a user message. Current Claude Code stores
+ * user turns as a content-block array; older transcripts used a plain string.
+ * Returns null for turns with no text blocks (e.g. tool_result-only messages),
+ * which should not be surfaced as user input.
+ */
+function userMessageText(
+  content: string | Array<{ type: string; text?: string }> | undefined,
+): string | null {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text as string);
+    return texts.length > 0 ? texts.join("\n") : null;
+  }
+  return null;
+}
+
 function detectCommandWarnings(name: string, input?: Record<string, unknown>): string[] {
   if (name !== "Bash" || !input || typeof input.command !== "string") return [];
   const cmd = input.command;
@@ -210,8 +229,10 @@ export function extractPreview(lines: JsonlLine[]): ConversationPreview {
     if (line.type === "progress" || line.type === "file-history-snapshot" || line.type === "system") continue;
     if (!line.message) continue;
 
-    if (line.type === "user" && typeof line.message.content === "string") {
-      const text = line.message.content.trim();
+    if (line.type === "user") {
+      const userText = userMessageText(line.message.content);
+      if (userText === null) continue;
+      const text = userText.trim();
 
       // Detect /clear command — reset preview state
       if (text === "/clear" || text.includes("<command-name>/clear</command-name>")) {
@@ -268,15 +289,16 @@ export function linesToConversation(lines: JsonlLine[]): ConversationMessage[] {
     if (line.type === "progress" || line.type === "file-history-snapshot" || line.type === "system") continue;
     if (!line.message) continue;
 
-    if (line.type === "user" && typeof line.message.content === "string") {
-      const rawText = line.message.content.trim();
+    if (line.type === "user") {
+      const userText = userMessageText(line.message.content);
+      if (userText === null) continue;
       // Skip system-injected messages (XML tags like <system-reminder>)
-      if (isSystemMessage(rawText)) continue;
+      if (isSystemMessage(userText.trim())) continue;
 
       messages.push({
         type: "user",
         timestamp: line.timestamp || "",
-        text: line.message.content,
+        text: userText,
         toolUses: [],
       });
     } else if (line.type === "assistant" && Array.isArray(line.message.content)) {
@@ -470,9 +492,9 @@ export function extractTaskSummary(headLines: JsonlLine[]): TaskSummary | null {
   // Strategy 2: Fall back to first user message (if it's not a generic prompt)
   for (const line of headLines) {
     if (line.type !== "user" || !line.message) continue;
-    const content = line.message.content;
-    if (typeof content !== "string") continue;
-    let text = content.trim();
+    const userText = userMessageText(line.message.content);
+    if (userText === null) continue;
+    let text = userText.trim();
     if (!text) continue;
 
     // Skip system-injected messages; try stripping XML tags for mixed content


### PR DESCRIPTION
Fixes #48 

## Fix

Add a `userMessageText()` helper that extracts text from either transcript form:

- string content → returned as-is;
- array content → text blocks joined;
- no text blocks (e.g. `tool_result`-only turns) → `null`, so tool results are not surfaced as user input.

Wire it into all three affected readers (`extractPreview`, `linesToConversation`, `extractTaskSummary`). Existing behavior — `/clear` reset, `<system-reminder>` filtering, length truncation, and the Linear `tool_result` task-summary path — is preserved.

A single shared helper keeps the three readers consistent and confines the format handling to one place, rather than branching on the content shape inline in each function.

## Testing

Added 8 unit tests covering the array form across all three readers:

- preview: text extraction, multi-block joining, `tool_result`-only skipping, XML filtering, `/clear` reset,
- conversation view: inclusion of array text / exclusion of `tool_result`-only turns,
- task summary: array fallback and `tool_result`-only skipping.

Full suite passes (150 tests). Verified against live sessions: prompts that previously rendered blank now appear in the session preview.
