### PR TITLE
feat: close related tabs on session cleanup

### DIFF
--- a/src/app/api/actions/open/route.ts
+++ b/src/app/api/actions/open/route.ts
@@ -2,6 +2,7 @@ import { exec, execFile } from "child_process";
 import { stat } from "fs/promises";
 import { NextResponse } from "next/server";
 import { promisify } from "util";
+import { CHROMIUM_BROWSERS } from "@/lib/close-tabs";
 import { BROWSER_OPTIONS, EDITOR_OPTIONS, GIT_GUI_OPTIONS, loadConfig } from "@/lib/config";
 import {
   buildProcessTree,
@@ -174,8 +175,7 @@ export async function POST(request: Request) {
         const browserDef = BROWSER_OPTIONS.find((b) => b.id === browserConfig.browser) ?? BROWSER_OPTIONS[0];
         const escapedUrl = escapeForAppleScript(url);
 
-        const chromiumBrowsers = ["Google Chrome", "Arc", "Brave Browser", "Microsoft Edge"];
-        if (chromiumBrowsers.includes(browserDef.appName)) {
+        if (CHROMIUM_BROWSERS.includes(browserDef.appName)) {
           const script = `
 tell application "${browserDef.appName}"
   set found to false

--- a/src/app/api/sessions/cleanup/route.ts
+++ b/src/app/api/sessions/cleanup/route.ts
@@ -1,14 +1,19 @@
 import { execFile } from "child_process";
 import { stat } from "fs/promises";
+import { basename } from "path";
 import { NextResponse } from "next/server";
 import { promisify } from "util";
+import { closeBrowserTab, closeGitGuiTab } from "@/lib/close-tabs";
+import { BROWSER_OPTIONS, GIT_GUI_OPTIONS, loadConfig } from "@/lib/config";
 import { isClaudeProcess } from "@/lib/process-utils";
+import { buildProcessTree, closeSession, detectAllTmuxPanes, detectTerminal, TerminalInfo } from "@/lib/terminal";
 
 const execFileAsync = promisify(execFile);
 
 interface CleanupRequest {
   pid: number | null;
   workingDirectory: string;
+  prUrl?: string | null;
 }
 
 async function killProcess(pid: number): Promise<void> {
@@ -97,10 +102,24 @@ async function deleteBranch(worktreeDir: string, branch: string): Promise<void> 
 export async function POST(request: Request) {
   try {
     const body: CleanupRequest = await request.json();
-    const { pid, workingDirectory } = body;
+    const { pid, workingDirectory, prUrl } = body;
 
     if (!workingDirectory) {
       return NextResponse.json({ error: "Missing workingDirectory" }, { status: 400 });
+    }
+
+    const config = await loadConfig();
+
+    // Resolve the terminal tab before killing the process — detection needs
+    // the live PID to find its TTY
+    let terminalInfo: TerminalInfo | null = null;
+    if (config.cleanupCloseTabs && pid) {
+      try {
+        const [tree, panes] = await Promise.all([buildProcessTree(), detectAllTmuxPanes()]);
+        terminalInfo = await detectTerminal(pid, tree, panes);
+      } catch {
+        // Can't resolve the terminal — skip tab cleanup for it
+      }
     }
 
     // Get the branch name before we tear things down
@@ -130,6 +149,17 @@ export async function POST(request: Request) {
     // Step 3: Delete the local branch
     if (branch) {
       await deleteBranch(workingDirectory, branch);
+    }
+
+    // Step 4: Close related tabs (opt-in via settings, all best-effort)
+    if (config.cleanupCloseTabs) {
+      const gitGui = GIT_GUI_OPTIONS.find((g) => g.id === config.gitGui);
+      const browser = BROWSER_OPTIONS.find((b) => b.id === config.browser);
+      await Promise.all([
+        terminalInfo ? closeSession(terminalInfo).catch(() => {}) : Promise.resolve(),
+        gitGui?.appName ? closeGitGuiTab(gitGui.appName, basename(workingDirectory)) : Promise.resolve(),
+        prUrl && browser ? closeBrowserTab(browser.appName, prUrl) : Promise.resolve(),
+      ]);
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -175,6 +175,7 @@ export async function PUT(request: Request) {
         typeof body.staleThresholdMinutes === "number" && body.staleThresholdMinutes >= 5
           ? Math.floor(body.staleThresholdMinutes)
           : current.staleThresholdMinutes,
+      cleanupCloseTabs: body.cleanupCloseTabs ?? current.cleanupCloseTabs,
     };
 
     await saveConfig(updated);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -48,6 +48,7 @@ interface SettingsData {
     defaultBaseBranch: string;
     showKeyboardHints: boolean;
     staleThresholdMinutes: number;
+    cleanupCloseTabs: boolean;
   };
   options: {
     editors: AppOptionDef[];
@@ -585,6 +586,19 @@ export default function SettingsPage() {
               className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-700/50 text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-hidden focus:border-zinc-600 transition-colors"
             />
           </div>
+        </div>
+      </section>
+
+      {/* Cleanup section */}
+      <section className="mb-10">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-3">Cleanup</h2>
+        <div className="rounded-xl border border-white/6 bg-[#0a0a0f]/80 px-5">
+          <Toggle
+            label="Close Related Tabs"
+            description="When cleaning up a session, also close its terminal tab, git GUI tab, and PR browser tab. Closing git GUI tabs requires accessibility permission."
+            enabled={data.config.cleanupCloseTabs ?? false}
+            onChange={(cleanupCloseTabs) => save({ cleanupCloseTabs })}
+          />
         </div>
       </section>
 

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useSettings } from "@/hooks/useSettings";
 import { ClaudeSession, PrStatus, SessionStatus } from "@/lib/types";
 import { GitSummary } from "./GitSummary";
 import { OutputPreview } from "./OutputPreview";
@@ -87,6 +88,7 @@ export function SessionCard({
   const displayStatus = isSuppressed ? (actedOn!.action === "reject" ? "idle" : "working") : session.status;
   const styles = cardStyles[displayStatus];
   const [cleanupState, setCleanupState] = useState<"idle" | "confirm" | "cleaning" | "done">("idle");
+  const { cleanupCloseTabs } = useSettings();
 
   const canCleanup =
     session.isWorktree && (displayStatus === "idle" || displayStatus === "waiting" || displayStatus === "finished");
@@ -111,6 +113,7 @@ export function SessionCard({
           body: JSON.stringify({
             pid: session.pid,
             workingDirectory: session.workingDirectory,
+            prUrl: session.prUrl,
           }),
         });
         if (res.ok) {
@@ -270,7 +273,9 @@ export function SessionCard({
           {/* Confirmation bar — slides in over the actions */}
           {cleanupState === "confirm" ? (
             <div className="flex items-center gap-2 cleanup-slide-in">
-              <span className="text-xs text-zinc-400 flex-1">Remove worktree and session?</span>
+              <span className="text-xs text-zinc-400 flex-1">
+                {cleanupCloseTabs ? "Remove worktree, session, and related tabs?" : "Remove worktree and session?"}
+              </span>
               <button
                 onClick={cancelCleanup}
                 className="px-3 py-1.5 rounded-lg text-xs text-zinc-500 hover:text-zinc-300 bg-white/4 hover:bg-white/8 border border-white/7 transition-colors"

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -13,6 +13,7 @@ interface SettingsResponse {
     editor: string;
     gitGui: string;
     staleThresholdMinutes: number;
+    cleanupCloseTabs: boolean;
   };
   options: {
     editors: AppOption[];
@@ -40,6 +41,7 @@ export function useSettings() {
     notificationSound: data?.config?.notificationSound ?? true,
     alwaysNotify: data?.config?.alwaysNotify ?? false,
     staleThresholdMinutes: data?.config?.staleThresholdMinutes ?? DEFAULT_STALE_THRESHOLD_MINUTES,
+    cleanupCloseTabs: data?.config?.cleanupCloseTabs ?? false,
     editorAvailable: isAppAvailable(data?.options?.editors, data?.config?.editor),
     gitGuiAvailable: isAppAvailable(data?.options?.gitGuis, data?.config?.gitGui),
   };

--- a/src/lib/close-tabs.test.ts
+++ b/src/lib/close-tabs.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Mock child_process.execFile, recording calls. Pass an error to make every call fail. */
+function mockExec(error?: Error) {
+  const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+    if (error) cb(error);
+    else cb(null, { stdout: "", stderr: "" });
+  });
+  vi.doMock("child_process", () => ({ execFile: execMock }));
+  return execMock;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("closeBrowserTab", () => {
+  it("closes the matching tab in Chromium browsers", async () => {
+    const execMock = mockExec();
+    const { closeBrowserTab } = await import("./close-tabs");
+
+    await closeBrowserTab("Google Chrome", "https://github.com/org/repo/pull/42");
+
+    const call = execMock.mock.calls.find((c) => c[0] === "osascript");
+    expect(call).toBeDefined();
+    const script = (call![1] as string[])[1];
+    expect(script).toContain('tell application "Google Chrome"');
+    expect(script).toContain("https://github.com/org/repo/pull/42");
+    expect(script).toContain("close aTab");
+  });
+
+  it("does nothing for non-Chromium browsers", async () => {
+    const execMock = mockExec();
+    const { closeBrowserTab } = await import("./close-tabs");
+
+    await closeBrowserTab("Firefox", "https://github.com/org/repo/pull/42");
+    await closeBrowserTab("Safari", "https://github.com/org/repo/pull/42");
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows osascript failures", async () => {
+    mockExec(new Error("not authorized"));
+    const { closeBrowserTab } = await import("./close-tabs");
+
+    await expect(closeBrowserTab("Arc", "https://example.com")).resolves.toBeUndefined();
+  });
+
+  it("escapes quotes in the url", async () => {
+    const execMock = mockExec();
+    const { closeBrowserTab } = await import("./close-tabs");
+
+    await closeBrowserTab("Google Chrome", 'https://example.com/?q="x"');
+
+    const script = (execMock.mock.calls[0][1] as string[])[1];
+    expect(script).toContain('\\"x\\"');
+  });
+});
+
+describe("closeGitGuiTab", () => {
+  it("clicks the close button of the window matching the folder name", async () => {
+    const execMock = mockExec();
+    const { closeGitGuiTab } = await import("./close-tabs");
+
+    await closeGitGuiTab("Fork", "my-repo-feature-x");
+
+    const call = execMock.mock.calls.find((c) => c[0] === "osascript");
+    expect(call).toBeDefined();
+    const script = (call![1] as string[])[1];
+    expect(script).toContain('tell application "System Events"');
+    expect(script).toContain('tell process "Fork"');
+    expect(script).toContain('is "my-repo-feature-x"');
+    expect(script).toContain("close button");
+  });
+
+  it("does nothing when no app name is configured", async () => {
+    const execMock = mockExec();
+    const { closeGitGuiTab } = await import("./close-tabs");
+
+    await closeGitGuiTab("", "my-repo");
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows osascript failures (e.g. missing accessibility permission)", async () => {
+    mockExec(new Error("osascript is not allowed assistive access"));
+    const { closeGitGuiTab } = await import("./close-tabs");
+
+    await expect(closeGitGuiTab("Fork", "my-repo")).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/close-tabs.ts
+++ b/src/lib/close-tabs.ts
@@ -1,0 +1,62 @@
+import { escapeForAppleScript, execFileAsync, OSASCRIPT_TIMEOUT_MS } from "./terminal/adapters/shared";
+
+/** Browsers whose tabs can be scripted via the Chromium AppleScript dictionary. */
+export const CHROMIUM_BROWSERS = ["Google Chrome", "Arc", "Brave Browser", "Microsoft Edge"];
+
+/**
+ * Close the first browser tab whose URL starts with `url`. Chromium browsers
+ * only — Safari and Firefox have no usable tab scripting here. Best-effort:
+ * failures are swallowed.
+ */
+export async function closeBrowserTab(appName: string, url: string): Promise<void> {
+  if (!CHROMIUM_BROWSERS.includes(appName)) return;
+
+  const escapedUrl = escapeForAppleScript(url);
+  const script = `tell application "${appName}"
+  set found to false
+  repeat with aWindow in windows
+    repeat with aTab in tabs of aWindow
+      if URL of aTab starts with "${escapedUrl}" then
+        close aTab
+        set found to true
+        exit repeat
+      end if
+    end repeat
+    if found then exit repeat
+  end repeat
+end tell`;
+
+  try {
+    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+  } catch {
+    // Best-effort — browser not running, or tab already gone
+  }
+}
+
+/**
+ * Close the git GUI tab for a repo. Git GUIs like Fork have no AppleScript
+ * dictionary, but use native macOS tabs — each tab appears to System Events
+ * as a window named after the repo folder, with a clickable close button.
+ * Requires accessibility permission; best-effort, failures are swallowed.
+ */
+export async function closeGitGuiTab(appName: string, folderName: string): Promise<void> {
+  if (!appName || !folderName) return;
+
+  const escapedName = escapeForAppleScript(folderName);
+  const script = `tell application "System Events"
+  tell process "${appName}"
+    repeat with aWindow in windows
+      if name of aWindow is "${escapedName}" then
+        click (first button of aWindow whose description is "close button")
+        exit repeat
+      end if
+    end repeat
+  end tell
+end tell`;
+
+  try {
+    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+  } catch {
+    // Best-effort — app not running, no accessibility permission, or tab already closed
+  }
+}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("loadConfig cleanupCloseTabs", () => {
+  it("defaults to false when no config file exists", async () => {
+    vi.doMock("fs/promises", () => ({
+      readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+    }));
+    const { loadConfig } = await import("./config");
+
+    const config = await loadConfig();
+
+    expect(config.cleanupCloseTabs).toBe(false);
+  });
+
+  it("preserves a stored true value", async () => {
+    vi.doMock("fs/promises", () => ({
+      readFile: vi.fn().mockResolvedValue(JSON.stringify({ cleanupCloseTabs: true })),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+    }));
+    const { loadConfig } = await import("./config");
+
+    const config = await loadConfig();
+
+    expect(config.cleanupCloseTabs).toBe(true);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -24,6 +24,7 @@ export interface AppConfig {
   defaultBaseBranch: string;
   showKeyboardHints: boolean;
   staleThresholdMinutes: number;
+  cleanupCloseTabs: boolean;
 }
 
 export const DEFAULT_INITIAL_PROMPT =
@@ -100,6 +101,7 @@ const DEFAULT_CONFIG: AppConfig = {
   defaultBaseBranch: "main",
   showKeyboardHints: true,
   staleThresholdMinutes: 90,
+  cleanupCloseTabs: false,
 };
 
 export async function loadConfig(): Promise<AppConfig> {

--- a/src/lib/terminal/adapters.test.ts
+++ b/src/lib/terminal/adapters.test.ts
@@ -355,6 +355,132 @@ describe("kitty adapter", () => {
   });
 });
 
+// ── closeSession tests ──────────────────────────────────────────────────────
+
+describe("closeSession", () => {
+  const baseInfo = {
+    appName: "iTerm2",
+    processName: "iTerm2",
+    pid: 12345,
+    inTmux: false,
+    tty: "/dev/ttys007",
+  };
+
+  /** Mock child_process.execFile, recording calls and succeeding. */
+  function mockExec(handler?: (bin: string, args: string[]) => string | null) {
+    const execMock = vi.fn().mockImplementation((...args: unknown[]) => {
+      const cb = args[args.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+      const stdout = handler?.(args[0] as string, args[1] as string[]) ?? "";
+      cb(null, { stdout, stderr: "" });
+    });
+    vi.doMock("child_process", () => ({ execFile: execMock }));
+    return execMock;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("kills the tmux pane when the session is in tmux", async () => {
+    const execMock = mockExec();
+    const { closeSession } = await import("./adapters");
+
+    await closeSession({
+      ...baseInfo,
+      app: "iterm",
+      inTmux: true,
+      tmux: {
+        paneId: "%5",
+        sessionName: "main",
+        windowIndex: 1,
+        paneIndex: 0,
+        target: "main:1.0",
+        clientPid: 500,
+        clientTty: "/dev/ttys003",
+      },
+    });
+
+    expect(execMock).toHaveBeenCalledWith(
+      expect.stringContaining("tmux"),
+      ["kill-pane", "-t", "%5"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    // Should not touch the terminal adapter — the terminal tab hosts the tmux client
+    expect(execMock).not.toHaveBeenCalledWith("osascript", expect.any(Array), expect.any(Object), expect.any(Function));
+  });
+
+  it("closes the iTerm session matching the tty", async () => {
+    const execMock = mockExec();
+    const { closeSession } = await import("./adapters");
+
+    await closeSession({ ...baseInfo, app: "iterm" });
+
+    const call = execMock.mock.calls.find((c) => c[0] === "osascript");
+    expect(call).toBeDefined();
+    const script = (call![1] as string[])[1];
+    expect(script).toContain('tell application "iTerm"');
+    expect(script).toContain("/dev/ttys007");
+    expect(script).toContain("close aSession");
+  });
+
+  it("closes the Terminal.app tab via focus + cmd-W", async () => {
+    const execMock = mockExec();
+    const { closeSession } = await import("./adapters");
+
+    await closeSession({ ...baseInfo, app: "terminal-app", appName: "Terminal", processName: "Terminal" });
+
+    const call = execMock.mock.calls.find((c) => c[0] === "osascript");
+    expect(call).toBeDefined();
+    const script = (call![1] as string[])[1];
+    expect(script).toContain('tell application "Terminal"');
+    expect(script).toContain("/dev/ttys007");
+    expect(script).toContain('keystroke "w" using command down');
+  });
+
+  it("closes the kitty window matching the pid", async () => {
+    const fakeLs = JSON.stringify([
+      { tabs: [{ windows: [{ id: 7, pid: 300, foreground_processes: [{ pid: 12345 }] }] }] },
+    ]);
+    vi.doMock("fs", () => ({ readdirSync: () => ["kitty-12345"] }));
+    const execMock = mockExec((bin, args) => (bin === "kitten" && args.includes("ls") ? fakeLs : null));
+    const { closeSession } = await import("./adapters");
+
+    await closeSession({ ...baseInfo, app: "kitty", appName: "kitty", processName: "kitty" });
+
+    expect(execMock).toHaveBeenCalledWith(
+      "kitten",
+      expect.arrayContaining(["close-window", "--match", "id:7"]),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("kills the WezTerm pane matching the tty", async () => {
+    const fakePanes = JSON.stringify([{ pane_id: 3, tab_id: 1, window_id: 1, tty_name: "/dev/ttys007" }]);
+    const execMock = mockExec((bin, args) => (bin.endsWith("wezterm") && args.includes("list") ? fakePanes : null));
+    const { closeSession } = await import("./adapters");
+
+    await closeSession({ ...baseInfo, app: "wezterm", appName: "WezTerm", processName: "wezterm-gui" });
+
+    expect(execMock).toHaveBeenCalledWith(
+      expect.stringContaining("wezterm"),
+      ["cli", "kill-pane", "--pane-id", "3"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("does nothing for terminals without closeSession support", async () => {
+    const execMock = mockExec();
+    const { closeSession } = await import("./adapters");
+
+    await closeSession({ ...baseInfo, app: "warp", appName: "Warp", processName: "Warp" });
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+});
+
 // ── Public API tmux delegation tests ────────────────────────────────────────
 
 describe("public API tmux handling", () => {

--- a/src/lib/terminal/adapters.ts
+++ b/src/lib/terminal/adapters.ts
@@ -32,6 +32,19 @@ export async function focusSession(info: TerminalInfo): Promise<void> {
   await adapter.focus(effectiveInfo);
 }
 
+export async function closeSession(info: TerminalInfo): Promise<void> {
+  // tmux: kill the pane — the terminal tab hosts the tmux client, which may
+  // still show other windows/panes, so leave it alone
+  if (info.inTmux && info.tmux) {
+    await execFileAsync(getTmuxBin(), ["kill-pane", "-t", info.tmux.paneId], { timeout: PROCESS_TIMEOUT_MS });
+    return;
+  }
+
+  const adapter = getAdapter(info.app);
+  if (!adapter?.closeSession) return; // Terminal doesn't support closing tabs
+  await adapter.closeSession(info);
+}
+
 export async function sendText(info: TerminalInfo, text: string): Promise<void> {
   // tmux: send directly to the pane — works in background without focus
   if (info.inTmux && info.tmux) {

--- a/src/lib/terminal/adapters/iterm.ts
+++ b/src/lib/terminal/adapters/iterm.ts
@@ -99,6 +99,23 @@ end tell`;
     await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
   },
 
+  async closeSession(info: TerminalInfo): Promise<void> {
+    const safeTty = escapeForAppleScript(info.tty);
+    const script = `tell application "iTerm"
+  repeat with aWindow in windows
+    repeat with aTab in tabs of aWindow
+      repeat with aSession in sessions of aTab
+        if tty of aSession is "${safeTty}" then
+          close aSession
+          return
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell`;
+    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+  },
+
   async createSession(command: string, opts: CreateSessionOpts): Promise<void> {
     const asCmd = escapeForAppleScript(command);
     const script =

--- a/src/lib/terminal/adapters/kitty.ts
+++ b/src/lib/terminal/adapters/kitty.ts
@@ -206,6 +206,13 @@ export const kittyAdapter: TerminalAdapter = {
     await genericFallback.sendKeystroke(info, keystroke);
   },
 
+  async closeSession(info: TerminalInfo): Promise<void> {
+    const windowId = await findKittyWindowId(info);
+    if (windowId !== null) {
+      await kittenRemote(["close-window", "--match", `id:${windowId}`]);
+    }
+  },
+
   async createSession(command: string, opts: CreateSessionOpts): Promise<void> {
     const launchArgs = [
       "launch",

--- a/src/lib/terminal/adapters/terminal-app.ts
+++ b/src/lib/terminal/adapters/terminal-app.ts
@@ -52,6 +52,14 @@ export const terminalAppAdapter: TerminalAdapter = {
     await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
   },
 
+  async closeSession(info: TerminalInfo): Promise<void> {
+    // Terminal.app's dictionary can't close individual tabs — select the tab
+    // first, then close it with cmd-W via System Events
+    const action = systemEventsScript("Terminal", `keystroke "w" using command down`);
+    const script = withFocusDelay(focusScript(info.tty), action, APPLESCRIPT_FOCUS_DELAY_S);
+    await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
+  },
+
   async createSession(command: string, opts: CreateSessionOpts): Promise<void> {
     const asCmd = escapeForAppleScript(command);
     // "do script in front window" opens a tab; plain "do script" opens a new window.

--- a/src/lib/terminal/adapters/types.ts
+++ b/src/lib/terminal/adapters/types.ts
@@ -24,4 +24,7 @@ export interface TerminalAdapter {
 
   /** Open a new terminal tab/window and run a command. */
   createSession(command: string, opts: CreateSessionOpts): Promise<void>;
+
+  /** Close the terminal tab/pane containing this session. Optional — not all terminals support it. */
+  closeSession?(info: TerminalInfo): Promise<void>;
 }

--- a/src/lib/terminal/adapters/wezterm.ts
+++ b/src/lib/terminal/adapters/wezterm.ts
@@ -132,6 +132,16 @@ export const weztermAdapter: TerminalAdapter = {
     await execFileAsync("osascript", ["-e", script], { timeout: OSASCRIPT_TIMEOUT_MS });
   },
 
+  async closeSession(info: TerminalInfo): Promise<void> {
+    const pane = await findPaneByTty(info.tty);
+    if (pane) {
+      const bin = resolveWeztermBin();
+      await execFileAsync(bin, ["cli", "kill-pane", "--pane-id", String(pane.pane_id)], {
+        timeout: CLI_TIMEOUT_MS,
+      });
+    }
+  },
+
   async createSession(command: string, opts: CreateSessionOpts): Promise<void> {
     const bin = resolveWeztermBin();
     if (opts.openIn === "tab") {

--- a/src/lib/terminal/index.ts
+++ b/src/lib/terminal/index.ts
@@ -1,5 +1,6 @@
 export type { CreateSessionPublicOpts as CreateSessionOpts } from "./adapters";
 export {
+  closeSession,
   createSession,
   focusSession,
   listTmuxSessions,


### PR DESCRIPTION
## Summary
- Adds an opt-in **Close Related Tabs** setting (new `cleanupCloseTabs` config, default off) with a toggle in the Settings → Cleanup section
- When cleaning up a session with the setting on, the cleanup route also closes the session's terminal tab/pane, the git GUI tab for the worktree, and the PR browser tab
- New `closeSession` on terminal adapters: tmux kills the pane; iTerm closes the session by tty; Terminal.app focuses the tab and sends cmd-W; kitty and WezTerm close via their CLIs; unsupported terminals are a no-op
- New `src/lib/close-tabs.ts` with `closeBrowserTab` (Chromium browsers only, matches tab by URL prefix) and `closeGitGuiTab` (System Events close-button click, requires accessibility permission); extracted the shared `CHROMIUM_BROWSERS` list
- SessionCard passes `prUrl` to the cleanup request and adjusts the confirmation copy when the setting is on

## Risk areas
- All tab closing is best-effort: failures (app not running, missing accessibility permission, tab already gone) are swallowed so cleanup itself never fails
- Terminal detection runs **before** the process is killed since it needs the live PID; if detection fails, tab cleanup is skipped silently
- Terminal.app close uses focus + synthesized cmd-W, which briefly steals focus

## Test plan
- [x] `npm test` — 165 tests pass, including new coverage for `closeSession` per adapter, `closeBrowserTab`/`closeGitGuiTab`, and config defaults
- [x] `eslint` and `tsc --noEmit` clean
- [ ] Manual: enable the toggle, clean up a worktree session, verify terminal tab, Fork tab, and PR tab close