### PR TITLE
feat: add Dia browser option

### DIFF
--- a/src/lib/close-tabs.test.ts
+++ b/src/lib/close-tabs.test.ts
@@ -30,6 +30,18 @@ describe("closeBrowserTab", () => {
     expect(script).toContain("close aTab");
   });
 
+  it("treats Dia as a Chromium browser", async () => {
+    const execMock = mockExec();
+    const { closeBrowserTab } = await import("./close-tabs");
+
+    await closeBrowserTab("Dia", "https://github.com/org/repo/pull/42");
+
+    const call = execMock.mock.calls.find((c) => c[0] === "osascript");
+    expect(call).toBeDefined();
+    const script = (call![1] as string[])[1];
+    expect(script).toContain('tell application "Dia"');
+  });
+
   it("does nothing for non-Chromium browsers", async () => {
     const execMock = mockExec();
     const { closeBrowserTab } = await import("./close-tabs");

--- a/src/lib/close-tabs.ts
+++ b/src/lib/close-tabs.ts
@@ -1,7 +1,7 @@
 import { escapeForAppleScript, execFileAsync, OSASCRIPT_TIMEOUT_MS } from "./terminal/adapters/shared";
 
 /** Browsers whose tabs can be scripted via the Chromium AppleScript dictionary. */
-export const CHROMIUM_BROWSERS = ["Google Chrome", "Arc", "Brave Browser", "Microsoft Edge"];
+export const CHROMIUM_BROWSERS = ["Google Chrome", "Arc", "Dia", "Brave Browser", "Microsoft Edge"];
 
 /**
  * Close the first browser tab whose URL starts with `url`. Chromium browsers

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -56,6 +56,7 @@ export const BROWSER_OPTIONS = [
   { id: "safari", label: "Safari", appName: "Safari" },
   { id: "chrome", label: "Google Chrome", appName: "Google Chrome" },
   { id: "arc", label: "Arc", appName: "Arc" },
+  { id: "dia", label: "Dia", appName: "Dia" },
   { id: "firefox", label: "Firefox", appName: "Firefox" },
   { id: "firefox-dev", label: "Firefox Developer Edition", appName: "Firefox Developer Edition" },
   { id: "brave", label: "Brave", appName: "Brave Browser" },


### PR DESCRIPTION
Closes #50.

## Summary
- Adds Dia (The Browser Company) to `BROWSER_OPTIONS` so it can be selected as the PR browser in settings
- Lists Dia in `CHROMIUM_BROWSERS` since it is Chromium-based, enabling AppleScript tab reuse in the open-url action and PR tab closing during cleanup

## Risk areas
- If Dia's AppleScript dictionary doesn't support tab scripting, the open-url action falls back to `open -a Dia` and tab closing is already best-effort, so nothing breaks

## Test plan
- [x] `npm test` — 166 tests pass, including a new test that `closeBrowserTab` scripts Dia as a Chromium browser
- [x] `eslint` and `tsc --noEmit` clean
- [ ] Manual: select Dia in settings, open a PR URL, verify tab reuse and cleanup tab closing